### PR TITLE
Use /usr/local/bin as default bin link dir

### DIFF
--- a/components/core/src/binlink.rs
+++ b/components/core/src/binlink.rs
@@ -15,7 +15,10 @@
 use env;
 
 /// Default Binlink Dir
+#[cfg(not(target_os = "macos"))]
 pub const DEFAULT_BINLINK_DIR: &'static str = "/bin";
+#[cfg(target_os = "macos")]
+pub const DEFAULT_BINLINK_DIR: &'static str = "/usr/local/bin";
 
 /// Binlink Dir Environment variable
 pub const BINLINK_DIR_ENVVAR: &'static str = "HAB_BINLINK_DIR";


### PR DESCRIPTION
On newish macs /bin is a protected driectory this change
makes binlinks go into /usr/local/bin.

Signed-off-by: Jon Morrow <jmorrow@chef.io>