### PR TITLE
Set up a SIGCHLD handler on Linux

### DIFF
--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -36,6 +36,7 @@ impl OsSignal for Signal {
             libc::SIGKILL => Some(Signal::KILL),
             libc::SIGSEGV => Some(Signal::SEGV),
             libc::SIGTERM => Some(Signal::TERM),
+            libc::SIGCHLD => Some(Signal::CHLD),
             _ => None,
         }
     }
@@ -54,6 +55,7 @@ impl OsSignal for Signal {
             Signal::ALRM => libc::SIGALRM,
             Signal::USR1 => libc::SIGUSR1,
             Signal::USR2 => libc::SIGUSR2,
+            Signal::CHLD => libc::SIGCHLD,
         }
     }
 }

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -46,6 +46,7 @@ pub enum Signal {
     ALRM,
     USR1,
     USR2,
+    CHLD,
 }
 
 impl From<i32> for Signal {
@@ -63,6 +64,7 @@ impl From<i32> for Signal {
             12 => Signal::USR2,
             14 => Signal::ALRM,
             15 => Signal::TERM,
+            17 => Signal::CHLD,
             _ => Signal::KILL,
         }
     }
@@ -83,6 +85,7 @@ impl From<Signal> for i32 {
             Signal::USR2 => 12,
             Signal::ALRM => 14,
             Signal::TERM => 15,
+            Signal::CHLD => 17,
         }
     }
 }

--- a/components/core/src/os/signals/mod.rs
+++ b/components/core/src/os/signals/mod.rs
@@ -19,6 +19,7 @@ use os::process;
 #[allow(dead_code)]
 pub enum SignalEvent {
     Shutdown,
+    WaitForChild,
     Passthrough(process::Signal),
 }
 


### PR DESCRIPTION
This will allow us to reap zombies when running the Launcher as PID 1. 
Without this, zombie processes would build up on a system, eventually 
filling up the process table. This would be a Bad Thing (TM).

While explicitly ignoring `SIGCHLD` with `SIG_IGN` would eliminate the
zombie problem, we would run into problems when the child process is
the Supervisor! We may need to restart it, so we have to actually
handle `SIGCHLD`.

Signed-off-by: Christopher Maier <cmaier@chef.io>