### PR TITLE
getting gid on windows should be a no-op

### DIFF
--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -37,8 +37,9 @@ pub fn get_uid_by_name(owner: &str) -> Option<String> {
     get_sid_by_name(owner)
 }
 
+// this is a no-op on windows
 pub fn get_gid_by_name(group: &str) -> Option<String> {
-    get_sid_by_name(group)
+    Some(String::new())
 }
 
 pub fn get_current_username() -> Option<String> {


### PR DESCRIPTION
Windows does not have the Linux concept of groups. So any value passed here to validate a group will either be empty or a dummy/meaningless string. We should always "succeed" by passing an empty string which windows implementations will never act on.

This addresses https://github.com/habitat-sh/habitat/issues/4685 allowing windows plans to leave out `$pkg_svc_group`. Without this change, users would need to include that when wanting to run under a non default `pkg_svc_user` and set it to a valid user. And well...thats pretty darn silly.

Signed-off-by: mwrock <matt@mattwrock.com>