### PR TITLE
 Use a backslash for windows FS_ROOT and PKG_PATH

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -428,7 +428,7 @@ fn fs_root_path() -> PathBuf {
     if cfg!(target_os = "windows") {
         match (henv::var(FS_ROOT_ENVVAR), henv::var(SYSTEMDRIVE_ENVVAR)) {
             (Ok(path), _) => PathBuf::from(path),
-            (Err(_), Ok(system_drive)) => PathBuf::from(format!("{}{}", system_drive, "/")),
+            (Err(_), Ok(system_drive)) => PathBuf::from(format!("{}{}", system_drive, "\\")),
             (Err(_), Err(_)) => {
                 unreachable!(
                     "Windows should always have a SYSTEMDRIVE \

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -36,7 +36,12 @@ pub const CACHE_SRC_PATH: &'static str = "hab/cache/src";
 /// The default path where SSL-related artifacts are placed
 pub const CACHE_SSL_PATH: &'static str = "hab/cache/ssl";
 /// The root path containing all locally installed packages
+/// Because this value is used in template rendering, we
+/// use native directory separator
+#[cfg(not(target_os = "windows"))]
 pub const PKG_PATH: &'static str = "hab/pkgs";
+#[cfg(target_os = "windows")]
+pub const PKG_PATH: &'static str = "hab\\pkgs";
 /// The environment variable pointing to the filesystem root. This exists for internal
 /// Habitat team usage and is not intended to be used by Habitat consumers.
 /// Using this variable could lead to broken Supervisor services and it should

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -16,7 +16,6 @@
 // We will need to create processes using different windows API calls in
 // order to be able to start habitat Supervisor services as different users.
 
-use std::ascii::AsciiExt;
 use std::cmp;
 use std::collections::HashMap;
 use std::env;


### PR DESCRIPTION
This ensures that the default `FS_ROOT` on windows ends in `\`. While almost all apps on windows handle forward slashes just as well as backslashes there are a few (like SQL Server 2016 (unlike 2017)) that may not understand forward slashes. This should fix those cases.