### PR TITLE
Add http-client crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ os: linux
 env:
   global:
     - PATH=$HOME/.cargo/bin:$PATH
-    # Habitat Core Rust crate components
-    - _RUST_HAB_LIB_COMPONENTS=components/core
 
 matrix:
   include:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 components/core @reset @fnichol @baumanj @christophermaier
 components/http-client @fnichol @raskchanky
+components/win-users @mwrock
 support @fnichol @baumanj @christophermaier

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+components/core @reset @fnichol @baumanj @christophermaier
+components/http-client @fnichol @raskchanky
+support @fnichol @baumanj @christophermaier

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +58,11 @@ dependencies = [
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -129,6 +139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +213,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat_http_client"
+version = "0.0.0"
+dependencies = [
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.186 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_core 0.0.0",
+ "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_win_users"
 version = "0.0.0"
 dependencies = [
@@ -225,6 +265,16 @@ dependencies = [
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper-openssl"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -365,6 +415,29 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.9.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -647,6 +720,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "version_check"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,12 +771,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
+"checksum cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9be26b24e988625409b19736d130f0c7d224f01d06454b5f81d8d23d6c1a618f"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clippy 0.0.186 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7b79c57f831e752f3667ae6115d02ed2d9e97a986ff76e5f04d613a8c0842a"
 "checksum clippy_lints 0.0.186 (registry+https://github.com/rust-lang/crates.io-index)" = "a3864104a4e6092e644b985dd7543e5f24e99aa7262f5ee400bcb17cfeec1bf5"
@@ -707,6 +787,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
@@ -714,6 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
+"checksum hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5ecb3cd8e4d53f8abe7cb2227e66674bb63c1bd0ba60ca9ba7b74ea1e0054891"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
@@ -733,6 +816,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
 "checksum num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9936036cc70fe4a8b2d338ab665900323290efb03983c86cbe235ae800ad8017"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
+"checksum openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdc5c4a02e69ce65046f1763a0181107038e02176233acb0b3351d7cc588f9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
@@ -770,6 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d28ea36bbd9192d75bd9fa9b39f96ddb986eaee824adae5d53b6e51919b2f3"
 "checksum users 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99ab1b53affc9f75f57da4a8b051a188e84d20d43bea0dd9bd8db71eebbca6da"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ debug = true
 [workspace]
 members = [
   "components/core",
+  "components/http-client",
   "components/win-users"
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LIB = core
+LIB = core http-client
 ALL = $(LIB)
 
 .DEFAULT_GOAL := build-lib

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "habitat_http_client"
+version = "0.0.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+build = "build.rs"
+workspace = "../../"
+
+[dependencies]
+clippy = {version = "*", optional = true}
+base64 = "*"
+log = "*"
+httparse = "*"
+hyper = "0.10"
+hyper-openssl = "0.2"
+# JB: pinning this for now to avoid a ton of breaking changes
+openssl = "0.9.23"
+serde = "*"
+serde_json = "*"
+url = "*"
+
+[dependencies.habitat_core]
+git = "https://github.com/habitat-sh/core.git"
+
+[features]
+default = []
+functional = []

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "*"
 url = "*"
 
 [dependencies.habitat_core]
-git = "https://github.com/habitat-sh/core.git"
+path = "../core"
 
 [features]
 default = []

--- a/components/http-client/build.rs
+++ b/components/http-client/build.rs
@@ -1,0 +1,23 @@
+fn main() {
+    inner::main()
+}
+
+#[cfg(not(target_os = "macos"))]
+mod inner {
+    use std::env;
+    use std::fs;
+    use std::path::Path;
+
+    pub fn main() {
+        let src = env::var("SSL_CERT_FILE").unwrap();
+        let dst = Path::new(&env::var("OUT_DIR").unwrap()).join("cacert.pem");
+        if !dst.exists() {
+            fs::copy(src, dst).unwrap();
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod inner {
+    pub fn main() {}
+}

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -1,0 +1,323 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+use std::time::Duration;
+
+use hab_core::util::sys;
+use hyper::client::{Client as HyperClient, IntoUrl, RequestBuilder};
+use hyper::client::pool::{Config, Pool};
+use hyper::header::UserAgent;
+use hyper::http::h1::Http11Protocol;
+use hyper::net::HttpsConnector;
+use hyper_openssl::OpensslClient;
+use openssl::ssl::{SslConnectorBuilder, SslConnector, SslMethod, SslOption, SSL_OP_NO_SSLV2,
+                   SSL_OP_NO_SSLV3, SSL_OP_NO_COMPRESSION};
+use url::Url;
+
+use error::{Error, Result};
+use net::ProxyHttpsConnector;
+use proxy::{ProxyInfo, proxy_unless_domain_exempted};
+use ssl;
+
+// Read and write TCP socket timeout for Hyper/HTTP client calls.
+const CLIENT_SOCKET_RW_TIMEOUT: u64 = 60;
+
+header! { (ProxyAuthorization, "Proxy-Authorization") => [String] }
+
+/// A generic wrapper around a Hyper HTTP client intended for API-like usage.
+///
+/// When an `ApiClient` is created, it has a constant URL base which is assumed to be some API
+/// endpoint. This allows the underlying Hyper client to load and use any relevant HTTP proxy
+/// support and to provide reasonable User-Agent HTTP headers, etc.
+#[derive(Debug)]
+pub struct ApiClient {
+    /// The base URL for the client.
+    endpoint: Url,
+    /// An instance of a `hyper::Client` which is configured with an SSL context and optionally
+    /// using an HTTP proxy.
+    inner: HyperClient,
+    /// Proxy information, if a proxy is being used.
+    proxy: Option<ProxyInfo>,
+    /// The URL scheme of the endpoint.
+    target_scheme: String,
+    /// The `User-Agent` header string to use for HTTP calls.
+    user_agent_header: UserAgent,
+}
+
+impl ApiClient {
+    /// Creates and returns a new `ApiClient` instance.
+    ///
+    /// # Errors
+    ///
+    /// * If the underlying Hyper client cannot be created
+    /// * If a suitable SSL context cannot be established
+    /// * If an HTTP proxy cannot be correctly setup
+    /// * If a `User-Agent` HTTP header string cannot be constructed
+    pub fn new<T>(
+        endpoint: T,
+        product: &str,
+        version: &str,
+        fs_root_path: Option<&Path>,
+    ) -> Result<Self>
+    where
+        T: IntoUrl,
+    {
+        let endpoint = endpoint.into_url().map_err(Error::UrlParseError)?;
+        Ok(ApiClient {
+            inner: new_hyper_client(&endpoint, fs_root_path)?,
+            proxy: proxy_unless_domain_exempted(Some(&endpoint))?,
+            target_scheme: endpoint.scheme().to_string(),
+            endpoint: endpoint,
+            user_agent_header: user_agent(product, version)?,
+        })
+    }
+
+    /// Builds an HTTP GET request for a given path.
+    pub fn get(&self, path: &str) -> RequestBuilder {
+        self.get_with_custom_url(path, |_| {})
+    }
+
+    /// Builds an HTTP GET request for a given path with the ability to customize the target URL.
+    pub fn get_with_custom_url<F>(&self, path: &str, mut customize_url: F) -> RequestBuilder
+    where
+        F: FnMut(&mut Url),
+    {
+        let mut url = self.url_for(path);
+        customize_url(&mut url);
+        debug!("GET {} with {:?}", &url, &self);
+        self.add_headers(self.inner.get(url))
+    }
+
+    /// Builds an HTTP HEAD request for a given path.
+    pub fn head(&self, path: &str) -> RequestBuilder {
+        self.head_with_custom_url(path, |_| {})
+    }
+
+    /// Builds an HTTP HEAD request for a given path with the ability to customize the target URL.
+    pub fn head_with_custom_url<F>(&self, path: &str, mut customize_url: F) -> RequestBuilder
+    where
+        F: FnMut(&mut Url),
+    {
+        let mut url = self.url_for(path);
+        customize_url(&mut url);
+        debug!("HEAD {} with {:?}", &url, &self);
+        self.add_headers(self.inner.head(url))
+    }
+
+    /// Builds an HTTP PATCH request for a given path.
+    pub fn patch(&self, path: &str) -> RequestBuilder {
+        self.patch_with_custom_url(path, |_| {})
+    }
+
+    /// Builds an HTTP PATCH request for a given path with the ability to customize the target URL.
+    pub fn patch_with_custom_url<F>(&self, path: &str, mut customize_url: F) -> RequestBuilder
+    where
+        F: FnMut(&mut Url),
+    {
+        let mut url = self.url_for(path);
+        customize_url(&mut url);
+        debug!("PATH {} with {:?}", &url, &self);
+        self.add_headers(self.inner.patch(url))
+    }
+
+    /// Builds an HTTP POST request for a given path.
+    pub fn post(&self, path: &str) -> RequestBuilder {
+        self.post_with_custom_url(path, |_| {})
+    }
+
+    /// Builds an HTTP POST request for a given path with the ability to customize the target URL.
+    pub fn post_with_custom_url<F>(&self, path: &str, mut customize_url: F) -> RequestBuilder
+    where
+        F: FnMut(&mut Url),
+    {
+        let mut url = self.url_for(path);
+        customize_url(&mut url);
+        debug!("POST {} with {:?}", &url, &self);
+        self.add_headers(self.inner.post(url))
+    }
+
+    /// Builds an HTTP PUT request for a given path.
+    pub fn put(&self, path: &str) -> RequestBuilder {
+        self.put_with_custom_url(path, |_| {})
+    }
+
+    /// Builds an HTTP PUT request for a given path with the ability to customize the target URL.
+    pub fn put_with_custom_url<F>(&self, path: &str, mut customize_url: F) -> RequestBuilder
+    where
+        F: FnMut(&mut Url),
+    {
+        let mut url = self.url_for(path);
+        customize_url(&mut url);
+        debug!("PUT {} with {:?}", &url, &self);
+        self.add_headers(self.inner.put(url))
+    }
+
+    /// Builds an HTTP DELETE request for a given path.
+    pub fn delete(&self, path: &str) -> RequestBuilder {
+        self.delete_with_custom_url(path, |_| {})
+    }
+
+    /// Builds an HTTP DELETE request for a given path with the ability to customize the target URL.
+    pub fn delete_with_custom_url<F>(&self, path: &str, mut customize_url: F) -> RequestBuilder
+    where
+        F: FnMut(&mut Url),
+    {
+        let mut url = self.url_for(path);
+        customize_url(&mut url);
+        debug!("DELETE {} with {:?}", &url, &self);
+        self.add_headers(self.inner.delete(url))
+    }
+
+    fn add_headers<'a>(&'a self, rb: RequestBuilder<'a>) -> RequestBuilder {
+        let mut rb = rb.header(self.user_agent_header.clone());
+        // If the target URL is an `"http"` scheme and we're using a proxy server, then add the
+        // proxy authorization header if appropriate. Note that for `"https"` targets, the proxy
+        // server will be operating in TCP tunneling mode and will be authenticated on connection to
+        // the proxy server which is why we should not add an additional header in this latter
+        // case.
+        if self.target_scheme == "http" {
+            if let Some(ref info) = self.proxy {
+                if let Some(header_value) = info.authorization_header_value() {
+                    rb = rb.header(ProxyAuthorization(header_value));
+                }
+            }
+        }
+        rb
+    }
+
+    fn url_for(&self, path: &str) -> Url {
+        let mut url = self.endpoint.clone();
+
+        if path.is_empty() {
+            return url;
+        }
+
+        if url.path().ends_with("/") || path.starts_with("/") {
+            url.set_path(&format!("{}{}", self.endpoint.path(), path));
+        } else {
+            url.set_path(&format!("{}/{}", self.endpoint.path(), path));
+        }
+
+        url
+    }
+}
+
+/// Builds a new hyper HTTP client with appropriate SSL configuration and HTTP/HTTPS proxy support.
+///
+/// ## Linux Platforms
+///
+/// We need a set of root certificates when connected to SSL/TLS web endpoints and this usually
+/// boiled down to using an all-in-one certificate file (such as a `cacert.pem` file) or a directory
+/// of files which are certificates. The strategy to location or use a reasonable set of
+/// certificates is as follows:
+///
+/// 1. If the `SSL_CERT_FILE` environment variable is set, then use its value for the certificates.
+///    Internally this is triggering default OpenSSL behavior for this environment variable.
+/// 2. If the `SSL_CERT_DIR` environment variable is set, then use its value for the directory
+///    containing certificates. Like the `SSL_CERT_FILE` case above, this triggers default OpenSSL
+///    behavior for this environment variable.
+/// 3. If the `core/cacerts` Habitat package is installed locally, then use the latest release's
+///    `cacert.pem` file.
+/// 4. If none of the conditions above are met, then a `cacert.pem` will be written in an SSL cache
+///    directory (by default `/hab/cache/ssl` for a root user and `$HOME/.hab/cache/ssl` for a
+///    non-root user) and this will be used. The contents of this file will be inlined in this
+///    crate at build time as a fallback insurance policy, meaning that if the a program using this
+///    code is operating in a minimal environment which may not contain system certificates, it can
+///    still operate. Once a `core/cacerts` Habitat package is present, the logic would fall back
+///    to preferring the package version to the cached/inline file version.
+///
+/// ## Mac Platforms
+///
+/// The Mac platform uses a Security Framework to store and find root certificates and the hyper
+/// library will default to using this on the Mac. Therefore the behavior on the Mac remains
+/// unchanged and will use the system's certificates.
+///
+fn new_hyper_client(url: &Url, fs_root_path: Option<&Path>) -> Result<HyperClient> {
+    let connector = ssl_connector(fs_root_path)?;
+    let ssl_client = OpensslClient::from(connector);
+    let timeout = Some(Duration::from_secs(CLIENT_SOCKET_RW_TIMEOUT));
+
+    match proxy_unless_domain_exempted(Some(url))? {
+        Some(proxy) => {
+            debug!("Using proxy {}:{}...", proxy.host(), proxy.port());
+            let connector = ProxyHttpsConnector::new(proxy, ssl_client)?;
+            let pool = Pool::with_connector(Config::default(), connector);
+            let mut client = HyperClient::with_protocol(Http11Protocol::with_connector(pool));
+            client.set_read_timeout(timeout);
+            client.set_write_timeout(timeout);
+            Ok(client)
+        }
+        None => {
+            let connector = HttpsConnector::new(ssl_client);
+            let pool = Pool::with_connector(Config::default(), connector);
+            let mut client = HyperClient::with_protocol(Http11Protocol::with_connector(pool));
+            client.set_read_timeout(timeout);
+            client.set_write_timeout(timeout);
+            Ok(client)
+        }
+    }
+}
+
+/// Returns an HTTP User-Agent string type for use by Hyper when making HTTP requests.
+///
+/// The general form for Habitat-related clients are of the following form:
+///
+/// ```text
+/// <PRODUCT>/<VERSION> (<TARGET>; <KERNEL_RELEASE>)
+/// ```
+///
+/// where:
+///
+/// * `<PRODUCT>`: is the provided product name
+/// * `<VERSION>`: is the provided version string which may also include a release number
+/// * `<TARGET>`: is the machine architecture and the kernel separated by a dash in lower case
+/// * `<KERNEL_RELEASE>`: is the kernel release string from `uname`
+///
+/// For example:
+///
+/// ```text
+/// hab/0.6.0/20160606153031 (x86_64-darwin; 14.5.0)
+/// ```
+///
+/// # Errors
+///
+/// * If system information cannot be obtained via `uname`
+fn user_agent(product: &str, version: &str) -> Result<UserAgent> {
+    let uname = sys::uname()?;
+    let ua = format!(
+        "{}/{} ({}-{}; {})",
+        product.trim(),
+        version.trim(),
+        uname.machine.trim().to_lowercase(),
+        uname.sys_name.trim().to_lowercase(),
+        uname.release.trim().to_lowercase()
+    );
+    debug!("User-Agent: {}", &ua);
+    Ok(UserAgent(ua))
+}
+
+fn ssl_connector(fs_root_path: Option<&Path>) -> Result<SslConnector> {
+    let mut conn = SslConnectorBuilder::new(SslMethod::tls())?;
+    let mut options = SslOption::empty();
+    options.toggle(SSL_OP_NO_SSLV2);
+    options.toggle(SSL_OP_NO_SSLV3);
+    options.toggle(SSL_OP_NO_COMPRESSION);
+    ssl::set_ca(conn.builder_mut(), fs_root_path)?;
+    conn.builder_mut().set_options(options);
+    conn.builder_mut().set_cipher_list(
+        "ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH",
+    )?;
+    Ok(conn.build())
+}

--- a/components/http-client/src/error.rs
+++ b/components/http-client/src/error.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error;
+use std::io;
+use std::fmt;
+use std::result;
+
+use hab_core;
+use hyper;
+use openssl::{self, ssl};
+use serde_json;
+use url;
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    HabitatCore(hab_core::Error),
+    HyperError(hyper::error::Error),
+    /// Occurs when an improper http or https proxy value is given.
+    InvalidProxyValue(String),
+    IO(io::Error),
+    Json(serde_json::Error),
+    SslError(ssl::Error),
+    SslErrorStack(openssl::error::ErrorStack),
+    /// When an error occurs attempting to parse a string into a URL.
+    UrlParseError(url::ParseError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::HabitatCore(ref e) => format!("{}", e),
+            Error::HyperError(ref err) => format!("{}", err),
+            Error::IO(ref e) => format!("{}", e),
+            Error::Json(ref e) => format!("{}", e),
+            Error::InvalidProxyValue(ref e) => format!("Invalid proxy value: {:?}", e),
+            Error::SslError(ref e) => format!("{}", e),
+            Error::SslErrorStack(ref e) => format!("{}", e),
+            Error::UrlParseError(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HabitatCore(ref err) => err.description(),
+            Error::HyperError(ref err) => err.description(),
+            Error::IO(ref err) => err.description(),
+            Error::Json(ref err) => err.description(),
+            Error::InvalidProxyValue(_) => "Invalid proxy value",
+            Error::SslError(ref err) => err.description(),
+            Error::SslErrorStack(ref err) => err.description(),
+            Error::UrlParseError(ref err) => err.description(),
+        }
+    }
+}
+
+impl From<hab_core::Error> for Error {
+    fn from(err: hab_core::Error) -> Error {
+        Error::HabitatCore(err)
+    }
+}
+
+impl From<hyper::error::Error> for Error {
+    fn from(err: hyper::error::Error) -> Error {
+        Error::HyperError(err)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IO(err)
+    }
+}
+
+impl From<ssl::Error> for Error {
+    fn from(err: ssl::Error) -> Error {
+        Error::SslError(err)
+    }
+}
+
+impl From<openssl::error::ErrorStack> for Error {
+    fn from(err: openssl::error::ErrorStack) -> Error {
+        Error::SslErrorStack(err)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(err: url::ParseError) -> Self {
+        Error::UrlParseError(err)
+    }
+}

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+extern crate base64;
+extern crate habitat_core as hab_core;
+extern crate httparse;
+#[macro_use]
+extern crate hyper;
+extern crate hyper_openssl;
+#[macro_use]
+extern crate log;
+extern crate openssl;
+extern crate serde;
+extern crate serde_json;
+extern crate url;
+
+pub mod api_client;
+pub mod error;
+pub mod net;
+pub mod proxy;
+pub mod util;
+
+pub use api_client::ApiClient;
+pub use error::{Error, Result};
+
+#[cfg(not(target_os = "macos"))]
+mod ssl {
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::Path;
+    use std::str::FromStr;
+
+    use hab_core::env;
+    use hab_core::fs::cache_ssl_path;
+    use hab_core::package::{PackageIdent, PackageInstall};
+    use openssl::ssl::SslContextBuilder;
+
+    use error::Result;
+
+    const CACERTS_PKG_IDENT: &'static str = "core/cacerts";
+    const CACERT_PEM: &'static str = include_str!(concat!(env!("OUT_DIR"), "/cacert.pem"));
+
+    pub fn set_ca(ctx: &mut SslContextBuilder, fs_root_path: Option<&Path>) -> Result<()> {
+        let cacerts_ident = PackageIdent::from_str(CACERTS_PKG_IDENT)?;
+
+        if let Ok(_) = env::var("SSL_CERT_FILE") {
+            ctx.set_default_verify_paths()?;
+        } else if let Ok(_) = env::var("SSL_CERT_DIR") {
+            ctx.set_default_verify_paths()?;
+        } else if let Ok(pkg_install) = PackageInstall::load(&cacerts_ident, fs_root_path) {
+            let pkg_certs = pkg_install.installed_path().join("ssl/cert.pem");
+            debug!(
+                "Setting CA file for SSL context to: {}",
+                pkg_certs.display()
+            );
+            ctx.set_ca_file(pkg_certs)?;
+        } else {
+            let cached_certs = cache_ssl_path(fs_root_path).join("cert.pem");
+            if !cached_certs.exists() {
+                fs::create_dir_all(cache_ssl_path(fs_root_path))?;
+                debug!("Creating cached cacert.pem at: {}", cached_certs.display());
+                let mut file = File::create(&cached_certs)?;
+                file.write_all(CACERT_PEM.as_bytes())?;
+            }
+            debug!(
+                "Setting CA file for SSL context to: {}",
+                cached_certs.display()
+            );
+            ctx.set_ca_file(cached_certs)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod ssl {
+    use std::path::Path;
+
+    use openssl::ssl::SslContextBuilder;
+
+    use error::Result;
+
+    pub fn set_ca(ctx: &mut SslContextBuilder, _fs_root_path: Option<&Path>) -> Result<()> {
+        ctx.set_default_verify_paths()?;
+        Ok(())
+    }
+}

--- a/components/http-client/src/net.rs
+++ b/components/http-client/src/net.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::{Read, Write};
+
+use httparse;
+use hyper;
+use hyper::method::Method;
+use hyper::version::HttpVersion;
+use hyper::net::{HttpConnector, HttpsStream, NetworkConnector, SslClient};
+
+use proxy::ProxyInfo;
+
+/// A connector that uses an HTTP proxy server (pass-through for plaintext and tunneled for SSL
+/// sessions).
+pub struct ProxyHttpsConnector<S: SslClient> {
+    proxy: ProxyInfo,
+    proxy_connector: HttpConnector,
+    ssl_client: S,
+}
+
+impl<S: SslClient> ProxyHttpsConnector<S> {
+    /// Creates a new connection using the provided proxy server configuration and SSL
+    /// implementation.
+    pub fn new(proxy: ProxyInfo, ssl: S) -> hyper::Result<Self> {
+        Ok(ProxyHttpsConnector {
+            proxy: proxy,
+            proxy_connector: HttpConnector,
+            ssl_client: ssl,
+        })
+    }
+}
+
+impl<S: SslClient> NetworkConnector for ProxyHttpsConnector<S> {
+    type Stream = HttpsStream<S::Stream>;
+
+    fn connect(&self, host: &str, port: u16, scheme: &str) -> hyper::Result<Self::Stream> {
+        // Initial connection to the proxy server, using an `HttpConnector`
+        let mut stream = self.proxy_connector.connect(
+            self.proxy.host(),
+            self.proxy.port(),
+            "http",
+        )?;
+        match scheme {
+            "https" => {
+                // If the target URL is an `"https"` scheme, then we use proxy/TCP tunneling as
+                // per the RFC draft:
+                // http://www.web-cache.com/Writings/Internet-Drafts/
+                // draft-luotonen-web-proxy-tunneling-01.txt
+                //
+                // We can't yet use hyper directly and therefore use the underlying http parsing
+                // library to establish the connection and parse the response. This implementation
+                // is largely based on hyper's internal proxy tunneling code.
+                let mut connect_msg = format!(
+                    "{method} {host}:{port} {version}\r\nHost: \
+                                               {host}:{port}\r\n",
+                    method = Method::Connect,
+                    version = HttpVersion::Http11,
+                    host = host,
+                    port = port
+                );
+                if let Some(header_value) = self.proxy.authorization_header_value() {
+                    connect_msg.push_str(&format!("Proxy-Authorization: {}\r\n", header_value));
+                };
+                connect_msg.push_str("\r\n");
+                debug!(
+                    "Proxy {}:{} {:?}",
+                    self.proxy.host(),
+                    self.proxy.port(),
+                    connect_msg.trim().replace("\r\n", ", ")
+                );
+                stream.write_all(connect_msg.as_bytes())?;
+                stream.flush()?;
+                let mut buf = [0; 1024];
+                let mut n = 0;
+                while n < buf.len() {
+                    n += stream.read(&mut buf[n..])?;
+                    let mut headers = [httparse::EMPTY_HEADER; 10];
+                    let mut res = httparse::Response::new(&mut headers);
+                    if res.parse(&buf[..n])?.is_complete() {
+                        let code = res.code.expect("complete parsing lost code");
+                        if code >= 200 && code < 300 {
+                            debug!(
+                                "Proxy {}:{} CONNECT success = {}",
+                                self.proxy.host(),
+                                self.proxy.port(),
+                                code
+                            );
+                            return self.ssl_client.wrap_client(stream, host).map(
+                                HttpsStream::Https,
+                            );
+                        } else {
+                            debug!(
+                                "Proxy {}:{} CONNECT failed response = {}",
+                                self.proxy.host(),
+                                self.proxy.port(),
+                                code
+                            );
+                            return Err(hyper::Error::Status);
+                        }
+                    }
+                }
+                Err(hyper::Error::TooLarge)
+            }
+            _ => Ok(HttpsStream::Http(stream)),
+        }
+    }
+}

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -1,0 +1,518 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use url::{self, Url};
+use url::percent_encoding::percent_decode;
+
+use base64;
+use hab_core::env;
+
+use error::{Error, Result};
+
+/// Configuration relating to an HTTP Proxy.
+///
+/// # Examples
+///
+/// A proxy server with no credentials required:
+///
+/// ```
+/// extern crate habitat_http_client;
+/// extern crate url;
+///
+/// use std::str::FromStr;
+/// use url::Url;
+/// use habitat_http_client::proxy::ProxyInfo;
+///
+/// fn main() {
+///     let url = Url::from_str("http://proxy.example.com:8001/").unwrap();
+///     let proxy = ProxyInfo::new(url, None).unwrap();
+///
+///     assert_eq!(proxy.scheme(), "http");
+///     assert_eq!(proxy.host(), "proxy.example.com");
+///     assert_eq!(proxy.port(), 8001);
+///     assert!(proxy.authorization_header_value().is_none());
+/// }
+/// ```
+///
+/// A proxy server using basic authorization:
+///
+/// ```
+/// extern crate habitat_http_client;
+/// extern crate url;
+///
+/// use std::str::FromStr;
+/// use url::Url;
+/// use habitat_http_client::proxy::{ProxyBasicAuthorization, ProxyInfo};
+///
+/// fn main() {
+///     let url = Url::from_str("http://proxy.example.com").unwrap();
+///     let authz = ProxyBasicAuthorization::new("foo".to_string(), "bar".to_string());
+///     let proxy = ProxyInfo::new(url, Some(authz)).unwrap();
+///
+///     assert_eq!(proxy.scheme(), "http");
+///     assert_eq!(proxy.host(), "proxy.example.com");
+///     assert_eq!(proxy.port(), 80);
+///     assert_eq!(proxy.authorization_header_value().unwrap(), "Basic Zm9vOmJhcg==");
+/// }
+/// ```
+///
+#[derive(Debug, PartialEq)]
+pub struct ProxyInfo {
+    /// Url for the proxy server.
+    url: Url,
+    /// Optional basic authorization credentials for the proxy server.
+    authorization: Option<ProxyBasicAuthorization>,
+}
+
+impl ProxyInfo {
+    /// Create and return a new `ProxyInfo`.
+    ///
+    /// # Errors
+    ///
+    /// * If the proxy scheme is invalid (i.e. not `"http"` or `"https"`)
+    /// * If the proxy `Url` has an empty host entry
+    /// * If the proxy `Url` has an unknown port number
+    pub fn new(url: Url, authorization: Option<ProxyBasicAuthorization>) -> Result<Self> {
+        match url.scheme() {
+            "http" | "https" => (),
+            scheme => {
+                let msg = format!("Invalid scheme {} for {}", &scheme, &url);
+                return Err(Error::InvalidProxyValue(msg));
+            }
+        }
+        if let None = url.host_str() {
+            return Err(Error::UrlParseError(url::ParseError::EmptyHost));
+        }
+        if let None = url.port_or_known_default() {
+            return Err(Error::UrlParseError(url::ParseError::InvalidPort));
+        }
+
+        Ok(ProxyInfo {
+            url: url,
+            authorization: authorization,
+        })
+    }
+
+    /// Returns the scheme for the proxy server.
+    pub fn scheme(&self) -> &str {
+        self.url.scheme()
+    }
+
+    /// Returns the host entry for the proxy server.
+    pub fn host(&self) -> &str {
+        // Note that `.unwrap()` can be called here as the constructor function ensures that this
+        // entry must not be empty.
+        self.url.host_str().unwrap()
+    }
+
+    /// Returns the port number for the proxy server.
+    pub fn port(&self) -> u16 {
+        // Note that `.unwrap()` can be called here as the constructor function ensures that this
+        // value must known.
+        self.url.port_or_known_default().unwrap()
+    }
+
+    /// Returns an `Option` of a `String` representing the value of a `Proxy-Authorization` HTTP
+    /// header.
+    pub fn authorization_header_value(&self) -> Option<String> {
+        match self.authorization {
+            Some(ref auth) => Some(auth.header_value()),
+            None => None,
+        }
+    }
+}
+
+/// Represents a set of `Basic` proxy authorization credentials.
+///
+/// # Examples
+///
+/// ```
+/// use habitat_http_client::proxy::ProxyBasicAuthorization;
+///
+/// let authz = ProxyBasicAuthorization::new("foo".to_string(), "bar".to_string());
+///
+/// assert_eq!(authz.header_value(), "Basic Zm9vOmJhcg==");
+/// ```
+///
+#[derive(Debug, PartialEq)]
+pub struct ProxyBasicAuthorization {
+    /// Username for Basic authorization.
+    username: String,
+    /// Password for Basic authorization.
+    password: String,
+}
+
+impl ProxyBasicAuthorization {
+    /// Creates and returns a new `ProxyBasicAuthorization` with the given username and password.
+    pub fn new(username: String, password: String) -> Self {
+        ProxyBasicAuthorization {
+            username: username,
+            password: password,
+        }
+    }
+
+    /// Returns a `String` containing the value for a `Proxy-Authorization` HTTP header.
+    pub fn header_value(&self) -> String {
+        format!(
+            "Basic {}",
+            base64::encode(format!("{}:{}", self.username, self.password).as_bytes())
+        )
+    }
+}
+
+/// Returns a `ProxyInfo` from the `http_proxy` environment variable, if it is set.
+///
+/// The value of `http_proxy` must be a parseable URL such as `http://proxy.company.com:8001/`
+/// otherwise a parsing error will be returned. If the port is not present, than the default port
+/// numbers of http/80 and https/443 will be returned. If the `http_proxy` environment variable is
+/// not set or is empty, then a `Result` of `None` will be returned.
+///
+/// References:
+///
+/// * https://www.gnu.org/software/wget/manual/html_node/Proxies.html
+/// * https://wiki.archlinux.org/index.php/proxy_settings
+/// * https://msdn.microsoft.com/en-us/library/hh272656(v=vs.120).aspx
+/// * http://www.cyberciti.biz/faq/linux-unix-set-proxy-environment-variable/
+///
+/// # Examples
+///
+/// Behavior when environment variable is set:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("http_proxy", "http://proxy.example.com:8001/");
+/// let info = proxy::http_proxy().unwrap().unwrap();
+///
+/// assert_eq!(info.scheme(), "http");
+/// assert_eq!(info.host(), "proxy.example.com");
+/// assert_eq!(info.port(), 8001);
+/// assert!(info.authorization_header_value().is_none());
+/// ```
+///
+/// Behavior when environment variable is set with basic auth credentials:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("http_proxy", "http://itsme:asecret@proxy.example.com");
+/// let info = proxy::http_proxy().unwrap().unwrap();
+///
+/// assert_eq!(info.scheme(), "http");
+/// assert_eq!(info.host(), "proxy.example.com");
+/// assert_eq!(info.port(), 80);
+/// assert_eq!(info.authorization_header_value().unwrap(), "Basic aXRzbWU6YXNlY3JldA==");
+/// ```
+///
+/// Behavior when both lower case and upper case environment variables are set:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("HTTP_PROXY", "http://upper.example.com");
+/// std::env::set_var("http_proxy", "http://lower.example.com");
+/// let info = proxy::http_proxy().unwrap().unwrap();
+///
+/// assert_eq!(info.host(), "lower.example.com");
+/// ```
+///
+/// Behavior when environment variable is empty:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("http_proxy", "");
+///
+/// assert!(proxy::http_proxy().unwrap().is_none());
+/// ```
+///
+/// # Errors
+///
+/// * If the value of the `http_proxy` environment variable cannot be parsed as a URL
+/// * If the URL scheme is not a valid type (currently only supported schemes are http and https)
+/// * If the URL is missing a host/domain segment
+/// * If the URL is missing a port number and a default cannot be determined
+pub fn http_proxy() -> Result<Option<ProxyInfo>> {
+    match env::var("http_proxy") {
+        Ok(url) => parse_proxy_url(&url),
+        _ => {
+            match env::var("HTTP_PROXY") {
+                Ok(url) => parse_proxy_url(&url),
+                _ => Ok(None),
+            }
+        }
+    }
+}
+
+/// Returns a `ProxyInfo` from the `https_proxy` environment variable, if it is set.
+///
+/// The value of `https_proxy` must be a parseable URL such as `https://proxy.company.com:8001/`
+/// otherwise a parsing error will be returned. If the port is not present, than the default port
+/// numbers of http/80 and https/443 will be returned. If the `https_proxy` environment variable is
+/// not set or is empty, then a `Result` of `None` will be returned.
+///
+/// References:
+///
+/// * https://www.gnu.org/software/wget/manual/html_node/Proxies.html
+/// * https://wiki.archlinux.org/index.php/proxy_settings
+/// * https://msdn.microsoft.com/en-us/library/hh272656(v=vs.120).aspx
+/// * http://www.cyberciti.biz/faq/linux-unix-set-proxy-environment-variable/
+///
+/// # Examples
+///
+/// Behavior when environment variable is set:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("https_proxy", "http://proxy.example.com:8001/");
+/// let info = proxy::https_proxy().unwrap().unwrap();
+///
+/// assert_eq!(info.scheme(), "http");
+/// assert_eq!(info.host(), "proxy.example.com");
+/// assert_eq!(info.port(), 8001);
+/// assert!(info.authorization_header_value().is_none());
+/// ```
+///
+/// Behavior when environment variable is set with basic auth credentials:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("https_proxy", "http://itsme:asecret@proxy.example.com");
+/// let info = proxy::https_proxy().unwrap().unwrap();
+///
+/// assert_eq!(info.scheme(), "http");
+/// assert_eq!(info.host(), "proxy.example.com");
+/// assert_eq!(info.port(), 80);
+/// assert_eq!(info.authorization_header_value().unwrap(), "Basic aXRzbWU6YXNlY3JldA==");
+/// ```
+///
+/// Behavior when both lower case and upper case environment variables are set:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("HTTPS_PROXY", "http://upper.example.com");
+/// std::env::set_var("https_proxy", "http://lower.example.com");
+/// let info = proxy::https_proxy().unwrap().unwrap();
+///
+/// assert_eq!(info.host(), "lower.example.com");
+/// ```
+///
+/// Behavior when environment variable is empty:
+///
+/// ```
+/// use std;
+/// use habitat_http_client::proxy;
+///
+/// std::env::set_var("https_proxy", "");
+///
+/// assert!(proxy::https_proxy().unwrap().is_none());
+/// ```
+///
+/// # Errors
+///
+/// * If the value of the `https_proxy` environment variable cannot be parsed as a URL
+/// * If the URL scheme is not a valid type (currently only supported schemes are http and https)
+/// * If the URL is missing a host/domain segment
+/// * If the URL is missing a port number and a default cannot be determined
+pub fn https_proxy() -> Result<Option<ProxyInfo>> {
+    match env::var("https_proxy") {
+        Ok(url) => parse_proxy_url(&url),
+        _ => {
+            match env::var("HTTPS_PROXY") {
+                Ok(url) => parse_proxy_url(&url),
+                _ => Ok(None),
+            }
+        }
+    }
+}
+
+/// Returns a `ProxyInfo` from either the `http_proxy` or `https_proxy` environment variable if
+/// either is set and the given domain name is not matched in the `no_proxy` environment variable
+/// domain extension set.
+///
+/// See the [`http_proxy()`] and [`https_proxy()`] functions for more details about the
+/// `http_proxy` and `https_proxy` environment variable parsing. This function honors the
+/// `no_proxy` environment variable which is assumed to be a comma separated set of domain
+/// extensions. If the given domain matches one of these extensions then no proxy information
+/// should be returned (i.e. a return of `Ok(None)`).
+///
+/// # Errors
+///
+/// * If either the [`http_proxy()`] or [`https_proxy()`] was unsuccessful
+///
+/// [`http_proxy()`]: #method.http_proxy
+/// [`https_proxy()`]: #method.https_proxy
+///
+/// # Examples
+///
+/// Behavior when domain matches extension set for http_proxy:
+///
+/// ```
+/// extern crate habitat_http_client;
+/// extern crate url;
+///
+/// use std::str::FromStr;
+/// use url::Url;
+/// use habitat_http_client::proxy;
+///
+/// fn main() {
+///     std::env::set_var("http_proxy", "http://proxy.example.com:8001/");
+///     std::env::set_var("no_proxy", "localhost,127.0.0.1,localaddress,.localdomain.com");
+///     let for_domain = Url::from_str("http://server.localdomain.com").unwrap();
+///     let info = proxy::proxy_unless_domain_exempted(Some(&for_domain)).unwrap();
+///
+///     assert!(info.is_none());
+/// }
+///
+/// ```
+///
+/// Behavior when domain matches extension set for https_proxy:
+///
+/// ```
+/// extern crate habitat_http_client;
+/// extern crate url;
+///
+/// use std::str::FromStr;
+/// use url::Url;
+/// use habitat_http_client::proxy;
+///
+/// fn main() {
+///     std::env::set_var("https_proxy", "http://proxy.example.com:8001/");
+///     std::env::set_var("no_proxy", "localhost,127.0.0.1,localaddress,.localdomain.com");
+///     let for_domain = Url::from_str("https://server.localdomain.com").unwrap();
+///     let info = proxy::proxy_unless_domain_exempted(Some(&for_domain)).unwrap();
+///
+///     assert!(info.is_none());
+/// }
+/// ```
+///
+/// Behavior when both lower case and uppercase environment variables are set:
+///
+/// ```
+/// extern crate habitat_http_client;
+/// extern crate url;
+///
+/// use std::str::FromStr;
+/// use url::Url;
+/// use habitat_http_client::proxy;
+///
+/// fn main() {
+///     std::env::set_var("HTTPS_PROXY", "http://upper.example.com");
+///     std::env::set_var("https_proxy", "http://lower.example.com");
+///     std::env::set_var("NO_PROXY", ".upper.localdomain.com");
+///     std::env::set_var("no_proxy", ".lower,localdomain.com");
+///     let for_domain = Url::from_str("https://server.lower.localdomain.com").unwrap();
+///     let info = proxy::proxy_unless_domain_exempted(Some(&for_domain)).unwrap();
+///
+///     assert!(info.is_none());
+/// }
+/// ```
+///
+/// Behavior when domain does not match extension set:
+///
+/// ```
+/// extern crate habitat_http_client;
+/// extern crate url;
+///
+/// use std::str::FromStr;
+/// use url::Url;
+/// use habitat_http_client::proxy;
+///
+/// fn main() {
+///     std::env::set_var("https_proxy", "http://itsme:asecret@proxy.example.com:8001/");
+///     std::env::set_var("no_proxy", "localhost,127.0.0.1,localaddress,.localdomain.com");
+///     let for_domain = Url::from_str("https://www.example.com").unwrap();
+///     let info = proxy::proxy_unless_domain_exempted(Some(&for_domain)).unwrap().unwrap();
+///
+///     assert_eq!(info.scheme(), "http");
+///     assert_eq!(info.host(), "proxy.example.com");
+///     assert_eq!(info.port(), 8001);
+///     assert_eq!(info.authorization_header_value().unwrap(), "Basic aXRzbWU6YXNlY3JldA==");
+/// }
+/// ```
+///
+pub fn proxy_unless_domain_exempted(for_domain: Option<&Url>) -> Result<Option<ProxyInfo>> {
+    let scheme = match for_domain {
+        Some(url) => url.scheme(),
+        None => "",
+    };
+    match env::var("no_proxy") {
+        Ok(domains) => process_no_proxy(for_domain, scheme, domains),
+        _ => {
+            match env::var("NO_PROXY") {
+                Ok(domains) => process_no_proxy(for_domain, scheme, domains),
+                _ => {
+                    match scheme {
+                        "https" => https_proxy(),
+                        _ => http_proxy(),
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn process_no_proxy(
+    for_domain: Option<&Url>,
+    scheme: &str,
+    domains: String,
+) -> Result<Option<ProxyInfo>> {
+    let domain = match for_domain {
+        Some(url) => url.host_str().unwrap_or(""),
+        None => "",
+    };
+    for extension in domains.split(',') {
+        if domain.ends_with(extension) {
+            debug!(
+                "Domain {} matches domain extension {} from no_proxy='{}'",
+                &domain,
+                &extension,
+                &domains
+            );
+            return Ok(None);
+        }
+    }
+    match scheme {
+        "https" => https_proxy(),
+        _ => http_proxy(),
+    }
+}
+
+fn parse_proxy_url(url: &str) -> Result<Option<ProxyInfo>> {
+    let url = Url::parse(&url)?;
+    let auth = match url.password() {
+        Some(password) => {
+            Some(ProxyBasicAuthorization::new(
+                percent_decode(url.username().as_bytes())
+                    .decode_utf8_lossy()
+                    .into_owned(),
+                percent_decode(password.as_bytes())
+                    .decode_utf8_lossy()
+                    .into_owned(),
+            ))
+        }
+        None => None,
+    };
+    Ok(Some(ProxyInfo::new(url, auth)?))
+}

--- a/components/http-client/src/util.rs
+++ b/components/http-client/src/util.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Read;
+
+use hyper::client::Response;
+use serde;
+use serde_json;
+
+use error::{Error, Result};
+
+pub fn decoded_response<T>(mut response: Response) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let mut encoded = String::new();
+    response.read_to_string(&mut encoded).map_err(Error::IO)?;
+    debug!("Body: {:?}", encoded);
+    let thing = serde_json::from_str(&encoded).map_err(Error::Json)?;
+    Ok(thing)
+}


### PR DESCRIPTION
Part of habitat-sh/habitat#4726; see that for context.

Follow-on PRs for converting `habitat-sh/habitat` and `habitat-sh/builder` to use this will come next.