### PR TITLE
[core] Implement `Cow<'a, PackageIdent>` for `PackageIdent`.

### DIFF
--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::cmp::{Ordering, PartialOrd};
 use std::fmt;
 use std::result;
@@ -271,6 +272,18 @@ impl Ord for PackageIdent {
             Ok(Ordering::Equal) => self.release.cmp(&other.release),
             Err(_) => Ordering::Less,
         }
+    }
+}
+
+impl<'a> From<PackageIdent> for Cow<'a, PackageIdent> {
+    fn from(pi: PackageIdent) -> Cow<'a, PackageIdent> {
+        Cow::Owned(pi)
+    }
+}
+
+impl<'a> From<&'a PackageIdent> for Cow<'a, PackageIdent> {
+    fn from(pi: &'a PackageIdent) -> Cow<'a, PackageIdent> {
+        Cow::Borrowed(pi)
     }
 }
 


### PR DESCRIPTION
This change will be used in the install logic in common to better
express fully qualified package identifiers by type.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>