### PR TITLE
[core] Add temporary Windows fallback in PackageInstall#paths().

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -464,23 +464,25 @@ impl PackageInstall {
         Ok(paths)
     }
 
+    fn parse_runtime_environment_metafile(body: &str) -> Result<HashMap<String, String>> {
+        let mut env = HashMap::new();
+        for line in body.lines() {
+            let parts: Vec<&str> = line.splitn(2, "=").collect();
+            if parts.len() != 2 {
+                return Err(Error::MetaFileMalformed(MetaFile::RuntimeEnvironment));
+            }
+            let key = parts[0].to_string();
+            let value = parts[1].to_string();
+            env.insert(key, value);
+        }
+        Ok(env)
+    }
+
     /// Return the embedded runtime environment specification for a
     /// package.
     pub fn runtime_environment(&self) -> Result<HashMap<String, String>> {
         match self.read_metafile(MetaFile::RuntimeEnvironment) {
-            Ok(body) => {
-                let mut env = HashMap::new();
-                for line in body.lines() {
-                    let parts: Vec<&str> = line.splitn(2, "=").collect();
-                    if parts.len() != 2 {
-                        return Err(Error::MetaFileMalformed(MetaFile::RuntimeEnvironment));
-                    }
-                    let key = parts[0].to_string();
-                    let value = parts[1].to_string();
-                    env.insert(key, value);
-                }
-                Ok(env)
-            }
+            Ok(ref body) => Self::parse_runtime_environment_metafile(body),
             Err(Error::MetaFileNotFound(MetaFile::RuntimeEnvironment)) => {
                 // If there was no RUNTIME_ENVIRONMENT, we can at
                 // least return a proper PATH


### PR DESCRIPTION
This change attempts to provide an answer when calling
`PacakgeInstall#paths()` on Windows-built packages after the Habitat
0.53.0 release on 2018-02-05. After this point the build program wasn't
creating a `PATH` metafile which is required by some core logic when
finding programs in packages, etc.

The `PATH` metafile creation was restored for Windows builds in
abitat-sh/habitat#895 and this change tries to deal with all Windows
packages built between these 2 events.

The `PATH` value in a present `RUNTIME_ENVIRONMENT` metafile will be
used if such a metafile is present, and otherwise falls back to
returning an empty `Vec<PathBuf>` as expected. A unit test attempting to
cover this edge case is also provided here.

As this edge case addresses a small number of packages, this commit can
likely be reverted/deleted in the near to medium term future when most
affected Windows packages would have been rebuilt.