### PR TITLE
Remove compiler warnings in `core` & `http-client`

### DIFF
--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -39,7 +39,7 @@ where
 
 pub fn hash_string(data: &str) -> String {
     let mut out = [0u8; libsodium_sys::crypto_generichash_BYTES];
-    let mut st = vec![0u8; (unsafe { libsodium_sys::crypto_generichash_statebytes() })];
+    let mut st = vec![0u8; unsafe { libsodium_sys::crypto_generichash_statebytes() }];
     let pst = unsafe {
         mem::transmute::<*mut u8, *mut libsodium_sys::crypto_generichash_state>(st.as_mut_ptr())
     };
@@ -53,7 +53,7 @@ pub fn hash_string(data: &str) -> String {
 
 pub fn hash_bytes(data: &[u8]) -> String {
     let mut out = [0u8; libsodium_sys::crypto_generichash_BYTES];
-    let mut st = vec![0u8; (unsafe { libsodium_sys::crypto_generichash_statebytes() })];
+    let mut st = vec![0u8; unsafe { libsodium_sys::crypto_generichash_statebytes() }];
     let pst = unsafe {
         mem::transmute::<*mut u8, *mut libsodium_sys::crypto_generichash_state>(st.as_mut_ptr())
     };
@@ -67,7 +67,7 @@ pub fn hash_bytes(data: &[u8]) -> String {
 
 pub fn hash_reader(reader: &mut BufReader<File>) -> Result<String> {
     let mut out = [0u8; libsodium_sys::crypto_generichash_BYTES];
-    let mut st = vec![0u8; (unsafe { libsodium_sys::crypto_generichash_statebytes() })];
+    let mut st = vec![0u8; unsafe { libsodium_sys::crypto_generichash_statebytes() }];
     let pst = unsafe {
         mem::transmute::<*mut u8, *mut libsodium_sys::crypto_generichash_state>(st.as_mut_ptr())
     };

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -314,9 +314,9 @@ fn ssl_connector(fs_root_path: Option<&Path>) -> Result<SslConnector> {
     options.toggle(SSL_OP_NO_SSLV2);
     options.toggle(SSL_OP_NO_SSLV3);
     options.toggle(SSL_OP_NO_COMPRESSION);
-    ssl::set_ca(conn.builder_mut(), fs_root_path)?;
-    conn.builder_mut().set_options(options);
-    conn.builder_mut().set_cipher_list(
+    ssl::set_ca(&mut conn, fs_root_path)?;
+    conn.set_options(options);
+    conn.set_cipher_list(
         "ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH",
     )?;
     Ok(conn.build())


### PR DESCRIPTION
## [core] Address Rust 1.25.0 compiler warnings in crypto module.

Removes the following warnings:

```
warning: unnecessary parentheses around function argument
  --> components/core/src/crypto/hash.rs:42:28
   |
42 |     let mut st = vec![0u8; (unsafe { libsodium_sys::crypto_generichash_statebytes() })];
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
   |
   = note: #[warn(unused_parens)] on by default

warning: unnecessary parentheses around function argument
  --> components/core/src/crypto/hash.rs:56:28
   |
56 |     let mut st = vec![0u8; (unsafe { libsodium_sys::crypto_generichash_statebytes() })];
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses

warning: unnecessary parentheses around function argument
  --> components/core/src/crypto/hash.rs:70:28
   |
70 |     let mut st = vec![0u8; (unsafe { libsodium_sys::crypto_generichash_statebytes() })];
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses

```

## [http-client] Address compiler warnings in api-client module.

Removes the following warnings:

```
warning: use of deprecated item 'openssl::ssl::SslConnectorBuilder::builder_mut': SslConnectorBuilder now implements DerefMut<Target=SslContextBuilder>
   --> components/http-client/src/api_client.rs:317:22
    |
317 |     ssl::set_ca(conn.builder_mut(), fs_root_path)?;
    |                      ^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default

warning: use of deprecated item 'openssl::ssl::SslConnectorBuilder::builder_mut': SslConnectorBuilder now implements DerefMut<Target=SslContextBuilder>
   --> components/http-client/src/api_client.rs:318:10
    |
318 |     conn.builder_mut().set_options(options);
    |          ^^^^^^^^^^^

warning: use of deprecated item 'openssl::ssl::SslConnectorBuilder::builder_mut': SslConnectorBuilder now implements DerefMut<Target=SslContextBuilder>
   --> components/http-client/src/api_client.rs:319:10
    |
319 |     conn.builder_mut().set_cipher_list(
    |          ^^^^^^^^^^^

```