### PR TITLE
[core] Introduce `RUNTIME_PATH` metafile support in `PackageInstall`.

### DIFF
--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -183,6 +183,7 @@ pub enum MetaFile {
     Path,
     ResolvedServices, // Composite-only
     RuntimeEnvironment,
+    RuntimePath,
     Services, // Composite-only
     SvcGroup,
     SvcUser,
@@ -211,6 +212,7 @@ impl fmt::Display for MetaFile {
             MetaFile::Path => "PATH",
             MetaFile::ResolvedServices => "RESOLVED_SERVICES",
             MetaFile::RuntimeEnvironment => "RUNTIME_ENVIRONMENT",
+            MetaFile::RuntimePath => "RUNTIME_PATH",
             MetaFile::Services => "SERVICES",
             MetaFile::SvcGroup => "SVC_GROUP",
             MetaFile::SvcUser => "SVC_USER",


### PR DESCRIPTION
This change introduces a net-new metafile in a package, called
`RUNTIME_PATH`. Its contents are a path separator-delimited collection
of path elements that need to be added to an environment's `$PATH`
(`$env:PATH` on Windows) before to command can be expected to run
correctly. Prior to this change, the location for this information was
in the `RUNTIME_ENVIRONMENT` metafile (or was dynamically computed using
fallback logic using `PATH`, `DEPS`, and `TDEPS` metafiles). Upstream
changes to the build program have split the PATH computing logic apart
from the RUNTIME_ENVIRONMENT layering logic which let us to introducing
a standalone piece of package metadata to represent this.

RUNTIME_PATH metafile
---------------------

(The following will be added to the reference documentation in the
`habitat-sh/habitat` repository)

A file that contains all directories that need to be prepended to an
environment's `$PATH` before a program in this package can be expected
to run correctly. The order of the elements are precise and meaningful
so should not be altered. This file is used in concert with
`RUNTIME_ENVIRONMENT` to compute the full set of environment variables
that should be added to an environment before running a program in this
package.

New public `PackageInstall#environment_for_command()` method
------------------------------------------------------------

Now that the runtime path is no longer taken directly from the
`RUNTIME_ENVIRONMENT` metafile, the full runtime environment needs to be
prepared, or derived with a combination of `RUNTIME_ENVIRONMENT` and
`RUNTIME_PATH`. In order to better communicate what a consumer of
`PackageInstall`'s public API should call, a new method called
`environment_for_command()` was added which returns a `HashMap` of
`Strings`, of which each entry is an environment variable/value key
pair. Furthermore, the existing `runtime_environment()` method was
turned private (as no external consumers need call this) and its method
comment was updated to reflect its current purpose: to simply load and
parse the contents of `RUNTIME_ENVIRONMENT` without any further
filtering.

All existing code which called `PackageInstall#runtime_environment()`
needs to be updated to call `PackageInstall#environment_for_command()`
instead. As both methods return the exact same type, no further work
needs to happen. These call sites are all present in the main
`habitat-sh/habitat` repository and so will be dealt with there.

Backwards compatible `RUNTIME_ENVIRONMENT` parsing
--------------------------------------------------

In an effort to allow older Supervisors (and other Habitat tools) to
understand newer packages containing `RUNTIME_PATH`, the build program
is continuing to write a `PATH` key in `RUNTIME_ENVIRONMENT`. However,
for Habitat tools which are built using this changeset, any `PATH` key
in `RUNTIME_ENVIRONMENT` will be explicitly dropped and ignored. That
leaves 5 backwards compatible cases to consider:

1. New Supervisor, new package with `RUNTIME_PATH` - The `RUNTIME_PATH`
and `RUNTIME_ENVIRONMENT` will be combined with
`PackageInstall#environment_for_command()` and returned together. Any
existing `PATH` key in `RUNTIME_ENVIRONMENT` will be ignored.
2. New Supervisor, old package post-`RUNTIME_ENVIRONMENT` - The
`RUNTIME_ENVIRONMENT` will be loaded into a `HashMap` and a `PATH` entry
will be added by dynamically computing the runtime path via
`PackageInstall#legacy_runtime_paths()`. Any existing `PATH` key in
`RUNTIME_ENVIRONMENT` will be ignored.
3. New Supervisor, old package pre-`RUNTIME_ENVIRONMENT` - An
empty `HashMap` will be used for a non-existant `RUNTIME_ENVIRONMENT`
metafile and a `PATH` entry will be added by dynamically computing the
runtime path via `PackageInstall#legacy_runtime_paths()`.
4. Old Supervisor post-`RUNTIME_ENVIRONMENT`, new package with
`RUNTIME_PATH` - The older Supervisor logic will read and use the `PATH`
from the `RUNTIME_ENVIRONMENT` metafile which is still being added by
the build program to handle this specific case.
5. Old Supervisor pre-`RUNTIME_ENVIRONMENT`, new package with
`RUNTIME_PATH` - The older Supervisor dynamically compute the runtime
path using `PATH`, `DEPS`, and `TDEPS` metafiles. Extra runtime
environment is not a factor here as the feature hadn't been added yet.

References habitat-sh/habitat#4962

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>