### PR TITLE
Add option for bypassing cert validation

### DIFF
--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use hab_core::env;
 use hab_core::util::sys;
 use hyper::client::{Client as HyperClient, IntoUrl, RequestBuilder};
 use hyper::client::pool::{Config, Pool};
@@ -23,7 +24,7 @@ use hyper::http::h1::Http11Protocol;
 use hyper::net::HttpsConnector;
 use hyper_openssl::OpensslClient;
 use openssl::ssl::{SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SslConnector, SslConnectorBuilder, SslMethod,
-                   SslOption, SSL_OP_NO_COMPRESSION};
+                   SslOption, SSL_OP_NO_COMPRESSION, SSL_VERIFY_NONE};
 use url::Url;
 
 use error::{Error, Result};
@@ -317,5 +318,10 @@ fn ssl_connector(fs_root_path: Option<&Path>) -> Result<SslConnector> {
     ssl::set_ca(&mut conn, fs_root_path)?;
     conn.set_options(options);
     conn.set_cipher_list("ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH")?;
+
+    if env::var("HAB_SSL_CERT_VERIFY_NONE").is_ok() {
+        conn.set_verify(SSL_VERIFY_NONE);
+    }
+
     Ok(conn.build())
 }


### PR DESCRIPTION
This change adds an option for bypassing SSL cert validation to the hab client. This can be useful as a workaround or for test purposes when working with self-signed or internal corp certificates that have not yet been added to the root trust chain. 

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-265865234](https://user-images.githubusercontent.com/13542112/39607397-a75d6676-4eef-11e8-8876-f84391507371.gif)
