### PR TITLE
[ci] Pin rustfmt by pinning to Rust 1.25.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - language: rust
       env:
         - COMPONENTS=lib
-      rust: stable
+      rust: 1.25.0
       sudo: required
       addons:
         apt:


### PR DESCRIPTION
When we upgrade to Rust 1.26.0 (most likely after the next Habitat
release) we can drop these pins back to `stable` which will revert us
back to using Rust 1.26.0 and *also* `rustfmt` 0.4.1.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>