### PR TITLE
 Bump to Rust 1.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - language: rust
       env:
         - COMPONENTS=lib
-      rust: stable
+      rust: 1.26.0
       sudo: required
       addons:
         apt:

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -21,10 +21,10 @@ use std::path::Path;
 use base64;
 use sodiumoxide::crypto::sign;
 
-use error::{Error, Result};
-use super::{SigKeyPair, HART_FORMAT_VERSION, SIG_HASH_TYPE};
 use super::hash;
 use super::keys::parse_name_with_rev;
+use super::{SigKeyPair, HART_FORMAT_VERSION, SIG_HASH_TYPE};
+use error::{Error, Result};
 
 /// Generate and sign a package
 pub fn sign<P1: ?Sized, P2: ?Sized>(src: &P1, dst: &P2, pair: &SigKeyPair) -> Result<()>
@@ -279,10 +279,10 @@ mod test {
 
     use tempdir::TempDir;
 
-    use super::*;
-    use super::super::{SigKeyPair, HART_FORMAT_VERSION, SIG_HASH_TYPE};
-    use super::super::test_support::*;
     use super::super::keys::parse_name_with_rev;
+    use super::super::test_support::*;
+    use super::super::{SigKeyPair, HART_FORMAT_VERSION, SIG_HASH_TYPE};
+    use super::*;
 
     #[test]
     fn sign_and_verify() {

--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -100,10 +100,10 @@ mod test {
     use std::io;
     use std::path::PathBuf;
 
+    use super::super::test_support::*;
+    use super::*;
     #[cfg(feature = "functional")]
     use hyper::{header, Client, Url};
-    use super::*;
-    use super::super::test_support::*;
 
     #[allow(dead_code)]
     fn mk_local_tmpdir() -> PathBuf {

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -17,16 +17,16 @@ use std::str;
 
 use base64;
 use sodiumoxide::crypto::box_;
-use sodiumoxide::crypto::sealedbox;
 use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::PublicKey as BoxPublicKey;
 use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::SecretKey as BoxSecretKey;
 use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::{gen_nonce, Nonce};
+use sodiumoxide::crypto::sealedbox;
 
-use error::{Error, Result};
-use super::{get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev,
-            read_key_bytes, read_key_bytes_from_str, write_keypair_files, KeyPair, KeyType};
 use super::super::{ANONYMOUS_BOX_FORMAT_VERSION, BOX_FORMAT_VERSION, PUBLIC_BOX_KEY_VERSION,
                    PUBLIC_KEY_SUFFIX, SECRET_BOX_KEY_SUFFIX, SECRET_BOX_KEY_VERSION};
+use super::{get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev,
+            read_key_bytes, read_key_bytes_from_str, write_keypair_files, KeyPair, KeyType};
+use error::{Error, Result};
 
 #[derive(Debug)]
 pub struct BoxSecret<'a> {
@@ -472,8 +472,8 @@ mod test {
 
     use tempdir::TempDir;
 
-    use super::BoxKeyPair;
     use super::super::super::test_support::*;
+    use super::BoxKeyPair;
 
     static VALID_KEY: &'static str = "service-key-valid.default@acme-20160509181736.box.key";
     static VALID_PUB: &'static str = "service-key-valid.default@acme-20160509181736.pub";

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::collections::HashSet;
-use std::fs;
 use std::fmt;
+use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufReader, BufWriter};
@@ -41,8 +41,8 @@ lazy_static! {
 }
 
 pub mod box_key_pair;
-pub mod sym_key;
 pub mod sig_key_pair;
+pub mod sym_key;
 
 enum KeyType {
     Sig,
@@ -577,14 +577,14 @@ mod test {
     use hex;
     use tempdir::TempDir;
 
+    use super::KeyType;
+    use super::PairType;
     use super::box_key_pair::BoxKeyPair;
     use super::sig_key_pair::SigKeyPair;
     use super::sym_key::SymKey;
-    use super::KeyType;
-    use super::PairType;
 
-    use super::TmpKeyfile;
     use super::super::test_support::*;
+    use super::TmpKeyfile;
 
     static VALID_KEY: &'static str = "ring-key-valid-20160504220722.sym.key";
     static VALID_KEY_AS_HEX: &'static str =

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -18,15 +18,15 @@ use std::path::{Path, PathBuf};
 use base64;
 use hex;
 use sodiumoxide::crypto::sign;
-use sodiumoxide::crypto::sign::ed25519::SecretKey as SigSecretKey;
 use sodiumoxide::crypto::sign::ed25519::PublicKey as SigPublicKey;
+use sodiumoxide::crypto::sign::ed25519::SecretKey as SigSecretKey;
 use sodiumoxide::randombytes::randombytes;
 
-use error::{Error, Result};
-use super::{get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev,
-            read_key_bytes, write_keypair_files, KeyPair, KeyType, PairType, TmpKeyfile};
 use super::super::{hash, PUBLIC_KEY_SUFFIX, PUBLIC_SIG_KEY_VERSION, SECRET_SIG_KEY_SUFFIX,
                    SECRET_SIG_KEY_VERSION};
+use super::{get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev,
+            read_key_bytes, write_keypair_files, KeyPair, KeyType, PairType, TmpKeyfile};
+use error::{Error, Result};
 
 pub type SigKeyPair = KeyPair<SigPublicKey, SigSecretKey>;
 
@@ -362,9 +362,9 @@ mod test {
 
     use tempdir::TempDir;
 
-    use super::SigKeyPair;
-    use super::super::PairType;
     use super::super::super::test_support::*;
+    use super::super::PairType;
+    use super::SigKeyPair;
 
     static VALID_KEY: &'static str = "origin-key-valid-20160509190508.sig.key";
     static VALID_PUB: &'static str = "origin-key-valid-20160509190508.pub";

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::fmt;
 
 use base64;
 use hex;
@@ -22,10 +22,10 @@ use sodiumoxide::crypto::secretbox;
 use sodiumoxide::crypto::secretbox::Key as SymSecretKey;
 use sodiumoxide::randombytes::randombytes;
 
-use error::{Error, Result};
+use super::super::{hash, SECRET_SYM_KEY_SUFFIX, SECRET_SYM_KEY_VERSION};
 use super::{get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev,
             read_key_bytes, write_keypair_files, KeyPair, KeyType, PairType, TmpKeyfile};
-use super::super::{hash, SECRET_SYM_KEY_SUFFIX, SECRET_SYM_KEY_VERSION};
+use error::{Error, Result};
 
 pub type SymKey = KeyPair<(), SymSecretKey>;
 
@@ -436,9 +436,9 @@ mod test {
 
     use tempdir::TempDir;
 
-    use super::SymKey;
-    use super::super::PairType;
     use super::super::super::test_support::*;
+    use super::super::PairType;
+    use super::SymKey;
 
     static VALID_KEY: &'static str = "ring-key-valid-20160504220722.sym.key";
     static VALID_NAME_WITH_REV: &'static str = "ring-key-valid-20160504220722";

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -226,12 +226,12 @@
 
 use std::path::{Path, PathBuf};
 
-pub use sodiumoxide::init;
 use env as henv;
+pub use sodiumoxide::init;
 
 pub use self::keys::box_key_pair::BoxKeyPair;
-pub use self::keys::sym_key::SymKey;
 pub use self::keys::sig_key_pair::SigKeyPair;
+pub use self::keys::sym_key::SymKey;
 use fs::cache_key_path;
 
 /// The suffix on the end of a public sig/box file
@@ -276,8 +276,8 @@ pub fn default_cache_key_path(fs_root_path: Option<&Path>) -> PathBuf {
 
 #[cfg(test)]
 pub mod test_support {
-    use std::io::Read;
     use std::fs::File;
+    use std::io::Read;
     use std::path::PathBuf;
 
     use time;

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -15,8 +15,8 @@
 use std::env;
 use std::error;
 use std::ffi;
-use std::io;
 use std::fmt;
+use std::io;
 use std::num;
 use std::path::PathBuf;
 use std::result;

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::result;
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::fmt;
 
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use serde_json;
 
 /// Sample envelope JSON payload
@@ -44,7 +44,7 @@ macro_rules! define_event_log {
         impl typemap::Key for EventLog {
             type Value = EventLogger;
         }
-    }
+    };
 }
 
 #[macro_export]

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -19,9 +19,9 @@ use std::str::FromStr;
 
 use users;
 
-use package::{Identifiable, PackageIdent, PackageInstall};
 use env as henv;
 use error::Result;
+use package::{Identifiable, PackageIdent, PackageInstall};
 
 /// The default root path of the Habitat filesystem
 pub const ROOT_PATH: &'static str = "hab";
@@ -435,10 +435,10 @@ fn fs_root_path() -> PathBuf {
 #[cfg(test)]
 mod test_find_command {
 
+    pub use super::find_command;
     use std::env;
     use std::fs;
     use std::path::PathBuf;
-    pub use super::find_command;
 
     #[allow(dead_code)]
     fn setup_pathext() {
@@ -462,8 +462,8 @@ mod test_find_command {
     }
 
     mod without_pathext_set {
-        use super::{setup_empty_pathext, setup_path};
         pub use super::find_command;
+        use super::{setup_empty_pathext, setup_path};
 
         fn setup_environment() {
             setup_path();
@@ -496,8 +496,8 @@ mod test_find_command {
         }
 
         mod argument_with_extension {
-            use std::fs::canonicalize;
             use super::{find_command, setup_environment};
+            use std::fs::canonicalize;
 
             #[test]
             fn command_exists() {
@@ -533,8 +533,8 @@ mod test_find_command {
 
     #[cfg(target_os = "windows")]
     mod with_pathext_set {
-        use super::{setup_path, setup_pathext};
         pub use super::find_command;
+        use super::{setup_path, setup_pathext};
 
         fn setup_environment() {
             setup_path();
@@ -576,8 +576,8 @@ mod test_find_command {
         }
 
         mod argument_with_extension {
-            use std::fs::canonicalize;
             use super::{find_command, setup_environment};
+            use std::fs::canonicalize;
 
             #[test]
             fn command_exists() {

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -71,19 +71,19 @@ extern crate winapi;
 pub use self::error::{Error, Result};
 
 pub mod binlink;
+pub mod channel;
 pub mod config;
 pub mod crypto;
 pub mod env;
 pub mod error;
+pub mod event;
 pub mod fs;
+pub mod os;
+pub mod output;
 pub mod package;
 pub mod service;
 pub mod url;
 pub mod util;
-pub mod os;
-pub mod output;
-pub mod event;
-pub mod channel;
 
 use std::path::PathBuf;
 
@@ -92,9 +92,13 @@ pub use os::users;
 
 pub const AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
 
-lazy_static!{
+lazy_static! {
     pub static ref PROGRAM_NAME: String = {
         let arg0 = std::env::args().next().map(|p| PathBuf::from(p));
-        arg0.as_ref().and_then(|p| p.file_stem()).and_then(|p| p.to_str()).unwrap().to_string()
+        arg0.as_ref()
+            .and_then(|p| p.file_stem())
+            .and_then(|p| p.to_str())
+            .unwrap()
+            .to_string()
     };
 }

--- a/components/core/src/os/filesystem/linux.rs
+++ b/components/core/src/os/filesystem/linux.rs
@@ -14,8 +14,8 @@
 
 use libc::{self, c_char, c_int, mode_t};
 
-pub use std::os::unix::fs::symlink;
 use std::ffi::CString;
+pub use std::os::unix::fs::symlink;
 
 use error::{Error, Result};
 

--- a/components/core/src/os/filesystem/windows.rs
+++ b/components/core/src/os/filesystem/windows.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use libc::c_int;
-use std::path::Path;
 use std::io;
+use std::path::Path;
 
 use error::Result;
 

--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -14,8 +14,8 @@
 
 use std::ffi::OsString;
 use std::io;
-use std::path::PathBuf;
 use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
 use std::process::Command;
 
 use libc::{self, pid_t};

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 use std::ffi::OsString;
+use std::io;
 use std::path::PathBuf;
 use std::process::{self, Command};
 use std::ptr;
-use std::io;
 
 use kernel32;
 use winapi;
 
-use error::{Error, Result};
 use super::{OsSignal, Signal};
+use error::{Error, Result};
 
 const STILL_ACTIVE: u32 = 259;
 

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -41,8 +41,8 @@ use winapi::winbase;
 use error::{Error, Result};
 use habitat_win_users::sid::{self, Sid};
 
-use super::super::users::get_current_username;
 use super::super::super::crypto::dpapi::decrypt;
+use super::super::users::get_current_username;
 
 lazy_static! {
     static ref CREATE_PROCESS_LOCK: Mutex<()> = Mutex::new(());

--- a/components/core/src/os/signals/unix.rs
+++ b/components/core/src/os/signals/unix.rs
@@ -14,8 +14,8 @@
 
 //! Traps and notifies UNIX signals.
 
-use std::sync::{Once, ONCE_INIT};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, ATOMIC_BOOL_INIT, ATOMIC_USIZE_INIT};
+use std::sync::{Once, ONCE_INIT};
 
 use os::process::{OsSignal, Signal, SignalCode};
 

--- a/components/core/src/os/system/linux.rs
+++ b/components/core/src/os/system/linux.rs
@@ -17,9 +17,9 @@ use std::mem;
 
 use libc;
 
-use os::system::Uname;
 use errno::errno;
 use error::{Error, Result};
+use os::system::Uname;
 
 pub fn uname() -> Result<Uname> {
     unsafe { uname_libc() }

--- a/components/core/src/os/system/mod.rs
+++ b/components/core/src/os/system/mod.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use error::Error;
 use std::fmt;
 use std::result;
 use std::str::FromStr;
-use error::Error;
 #[cfg(windows)]
 mod windows;
 

--- a/components/core/src/os/system/windows.rs
+++ b/components/core/src/os/system/windows.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use os::system::Uname;
 use error::Result;
+use os::system::Uname;
 
 pub fn uname() -> Result<Uname> {
     Ok(Uname {

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -32,14 +32,14 @@
 //! JSON object. It ignores the coloring option, and does _not_ ever log
 //! with ANSI color codes, but does honor the verbose flag.
 
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use std::fmt;
 use std::result;
+use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 
 use ansi_term::Colour::{Cyan, Green, White};
-use serde_json;
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+use serde_json;
 
 use PROGRAM_NAME;
 
@@ -279,19 +279,19 @@ macro_rules! outputln {
 #[macro_export]
 /// Works the same as format!, but uses our structured output formatter.
 macro_rules! output_format {
-    (preamble $preamble: expr, logkey $logkey:expr, $content: expr) => {
-        {
-            use $crate::output::StructuredOutput;
-            let trimmed_content = &$content.trim_right_matches('\n');
-            let so = StructuredOutput::new(&$preamble,
-                                           $logkey,
-                                           line!(),
-                                           file!(),
-                                           column!(),
-                                           trimmed_content);
-            format!("{}", so)
-        }
-    }
+    (preamble $preamble:expr,logkey $logkey:expr, $content:expr) => {{
+        use $crate::output::StructuredOutput;
+        let trimmed_content = &$content.trim_right_matches('\n');
+        let so = StructuredOutput::new(
+            &$preamble,
+            $logkey,
+            line!(),
+            file!(),
+            column!(),
+            trimmed_content,
+        );
+        format!("{}", so)
+    }};
 }
 
 #[cfg(test)]

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -20,11 +20,12 @@ use std::str::FromStr;
 
 use regex::Regex;
 
-use package::PackageTarget;
 use error::{Error, Result};
+use package::PackageTarget;
 
 lazy_static! {
-    static ref ORIGIN_NAME_RE: Regex = Regex::new(r"\A[a-z0-9][a-z0-9_-]*\z").expect("Unable to compile regex");
+    static ref ORIGIN_NAME_RE: Regex =
+        Regex::new(r"\A[a-z0-9][a-z0-9_-]*\z").expect("Unable to compile regex");
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Hash)]
@@ -390,8 +391,8 @@ pub fn is_valid_origin_name(origin: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::split_version;
+    use super::*;
     use std::cmp::Ordering;
     use std::cmp::PartialOrd;
 

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std;
-use std::collections::{HashMap, HashSet};
 use std::cmp::{Ordering, PartialOrd};
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt;
 use std::fs::{DirEntry, File};
@@ -25,8 +25,8 @@ use std::str::FromStr;
 use toml;
 use toml::Value;
 
-use super::{Identifiable, PackageIdent, PackageTarget, Target};
 use super::metadata::{parse_key_value, Bind, BindMapping, MetaFile, PackageType};
+use super::{Identifiable, PackageIdent, PackageTarget, Target};
 use error::{Error, Result};
 use fs;
 

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -119,8 +119,8 @@ impl FromStr for PackageTarget {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
     use os::system::{Architecture, Platform};
+    use std::str::FromStr;
 
     #[test]
     fn package_target_matches_current_operating_system() {

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::fmt;
-use std::result;
 use std::ops::{Deref, DerefMut};
+use std::result;
 use std::str::FromStr;
 
 use regex::Regex;

--- a/components/core/src/util/perm.rs
+++ b/components/core/src/util/perm.rs
@@ -107,8 +107,8 @@ mod tests {
 
     use tempdir::TempDir;
 
-    use error::Error;
     use super::*;
+    use error::Error;
 
     #[test]
     fn chmod_ok_test() {

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use hab_core::env;
 use hab_core::util::sys;
-use hyper::client::{Client as HyperClient, IntoUrl, RequestBuilder};
 use hyper::client::pool::{Config, Pool};
+use hyper::client::{Client as HyperClient, IntoUrl, RequestBuilder};
 use hyper::header::UserAgent;
 use hyper::http::h1::Http11Protocol;
 use hyper::net::HttpsConnector;

--- a/components/http-client/src/error.rs
+++ b/components/http-client/src/error.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::error;
-use std::io;
 use std::fmt;
+use std::io;
 use std::result;
 
 use hab_core;

--- a/components/http-client/src/net.rs
+++ b/components/http-client/src/net.rs
@@ -17,8 +17,8 @@ use std::io::{Read, Write};
 use httparse;
 use hyper;
 use hyper::method::Method;
-use hyper::version::HttpVersion;
 use hyper::net::{HttpConnector, HttpsStream, NetworkConnector, SslClient};
+use hyper::version::HttpVersion;
 
 use proxy::ProxyInfo;
 

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use url::{self, Url};
 use url::percent_encoding::percent_decode;
+use url::{self, Url};
 
 use base64;
 use hab_core::env;

--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ptr::null_mut;
 use std::io::Error;
+use std::ptr::null_mut;
 
 use widestring::WideCString;
-use winapi::{BOOL, LPCWSTR, LPDWORD, PSID, PSID_NAME_USE, SID_NAME_USE};
 use winapi::winerror::*;
+use winapi::{BOOL, LPCWSTR, LPDWORD, PSID, PSID_NAME_USE, SID_NAME_USE};
 
 use super::sid::Sid;
 

--- a/components/win-users/src/sid.rs
+++ b/components/win-users/src/sid.rs
@@ -14,9 +14,9 @@
 
 #![allow(non_snake_case)]
 
-use std::ptr::{copy, null_mut};
 use std::io;
 use std::mem;
+use std::ptr::{copy, null_mut};
 
 use kernel32::{self, LocalFree};
 use widestring::WideCString;

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -47,7 +47,6 @@ exit_with() {
 }
 
 program=$(basename $0)
-rf_version="0.3.8"
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596
@@ -58,12 +57,6 @@ fi
 info "Checking for rustfmt"
 if ! command -v rustfmt >/dev/null; then
   exit_with "Program \`rustfmt' not found on PATH, aborting" 1
-fi
-
-info "Checking for version $rf_version of rustfmt"
-actual="$(rustfmt --version | cut -d ' ' -f 1)"
-if [[ "$actual" != "$rf_version-nightly" ]]; then
-  exit_with "\`rustfmt' version $actual doesn't match expected: $rf_version" 2
 fi
 
 failed="$(mktemp -t "$(basename $0)-failed-XXXX")"


### PR DESCRIPTION
Cleanup work associated with https://github.com/habitat-sh/habitat/pull/5104

* Lock travis build to use Rust 1.26.0
* Reformat code for rustfmt contained with 1.26.0

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>