### PR TITLE
Change command to candidate when binlinking package

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -295,7 +295,7 @@ where
         ));
         let candidate = fs_root_path.as_ref().join(stripped).join(command.as_ref());
         if candidate.is_file() {
-            return Ok(Some(path.join(command.as_ref())));
+            return Ok(Some(path.join(candidate)));
         } else {
             match find_command_with_pathext(&candidate) {
                 Some(result) => return Ok(Some(result)),


### PR DESCRIPTION
This was causing packages to always get binlinked to /hab instead of respecting the FS_ROOT

![](https://media1.giphy.com/media/ADr35Z4TvATIc/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>