### PR TITLE
[ci] Update to Rust 1.27.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - language: rust
       env:
         - COMPONENTS=lib
-      rust: 1.27.0
+      rust: 1.27.1
       sudo: required
       addons:
         apt:


### PR DESCRIPTION
https://blog.rust-lang.org/2018/07/10/Rust-1.27.1.html

(Note that no code was updated after running `cargo fmt`).

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>