### PR TITLE
only trim trailing $ from windows account check if it is the local machine account

### DIFF
--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::io::Error;
 use std::ptr::null_mut;
 
@@ -56,11 +57,12 @@ fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
     // LookupAccountName will return the sid of the computer account
     // given the computer name. Windows forbids usernames to match the
     // computer name
-    let stripped_name = if name.ends_with("$") {
-        &name[..name.len() - 1]
-    } else {
-        name
-    };
+    let stripped_name =
+        if name.to_lowercase() == (env::var("COMPUTERNAME").unwrap().to_lowercase() + "$") {
+            &name[..name.len() - 1]
+        } else {
+            name
+        };
     let mut sid_size: u32 = 0;
     let mut domain_size: u32 = 0;
     let wide = WideCString::from_str(stripped_name).unwrap();
@@ -175,6 +177,14 @@ mod tests {
         assert_eq!(
             lower_sid.to_string().unwrap(),
             upper_sid.to_string().unwrap()
+        )
+    }
+
+    #[test]
+    fn machine_account_returns_some() {
+        assert_eq!(
+            Account::from_name((env::var("COMPUTERNAME").unwrap() + "$").as_str()).is_some(),
+            true
         )
     }
 }


### PR DESCRIPTION
This was detected in an enterprise environment running the supervisor under a GMSA account (an AD account where AD manages the password). There account names may end in a `$`. Previously I have only seen that with local machine accounts and `LookupAccountNameW` cannot find those accounts with the trailing `$`. However when validating the GMSA account `LookupAccountNameW` will require that trailing `$`. This PR only trims the `$` if it is indeed a local machine account.

We created a small dummy test program onsite to validate this `LookupAccountNameW` behavior. I have tested this locally with made up accounts that end in a `$`.

Signed-off-by: mwrock <matt@mattwrock.com>