### PR TITLE
Avoid unnecessary system calls during package lookup

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -17,14 +17,14 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt;
 use std::fs::File;
-use std::io::prelude::*;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use toml;
 use toml::Value;
 
-use super::all_packages;
+use super::list::package_list_for_ident;
 use super::metadata::{parse_key_value, read_metafile, Bind, BindMapping, MetaFile, PackageType};
 use super::{Identifiable, PackageIdent};
 use error::{Error, Result};
@@ -94,7 +94,8 @@ impl PackageInstall {
         if !package_root_path.exists() {
             return Err(Error::PackageNotFound(ident.clone()));
         }
-        let pl = all_packages(&package_root_path)?;
+
+        let pl = package_list_for_ident(&package_root_path, ident)?;
         if ident.fully_qualified() {
             if pl.iter().any(|ref p| p.satisfies(ident)) {
                 Ok(PackageInstall {
@@ -159,7 +160,7 @@ impl PackageInstall {
             return Err(Error::PackageNotFound(original_ident.clone()));
         }
 
-        let pl = all_packages(&package_root_path)?;
+        let pl = package_list_for_ident(&package_root_path, &original_ident)?;
         let latest: Option<PackageIdent> = pl
             .iter()
             .filter(|ref p| p.origin == ident.origin && p.name == ident.name)

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use std::fs;
-use std::fs::DirEntry;
-use std::path::Path;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use super::metadata::{read_metafile, MetaFile};
 use super::{PackageIdent, PackageTarget};
 
-use error::Result;
+use error::{Error, Result};
 
 pub const INSTALL_TMP_PREFIX: &'static str = ".hab-pkg-install";
 
@@ -33,126 +33,239 @@ pub fn all_packages(path: &Path) -> Result<Vec<PackageIdent>> {
     Ok(package_list)
 }
 
-/// Helper function for all_packages. Walks the given path for origin directories
-/// and builds on the given package list by recursing into name, version, and release
-/// directories.
+/// Returns a vector of package structs built from the contents of
+/// the given directory, using the given ident to restrict the
+/// search.
+///
+/// The search is restricted by assuming the package directory
+/// structure is:
+///
+///    /base/ORIGIN/NAME/VERSION/RELEASE/
+///
+pub fn package_list_for_ident(
+    base_pkg_path: &Path,
+    ident: &PackageIdent,
+) -> Result<Vec<PackageIdent>> {
+    let mut package_list: Vec<PackageIdent> = vec![];
+    let mut package_path = PathBuf::from(base_pkg_path);
+    package_path.push(&ident.origin);
+    package_path.push(&ident.name);
+
+    if !is_existing_dir(&package_path)? {
+        return Ok(package_list);
+    }
+
+    match (&ident.version, &ident.release) {
+        // origin/name
+        (None, _) => walk_versions(&ident.origin, &ident.name, &package_path, &mut package_list)?,
+        // origin/name/version
+        (Some(version), None) => {
+            package_path.push(version);
+            if !is_existing_dir(&package_path)? {
+                return Ok(package_list);
+            }
+            walk_releases(
+                &ident.origin,
+                &ident.name,
+                &version,
+                &package_path,
+                &mut package_list,
+            )?
+        }
+        // origin/name/version/release
+        (Some(version), Some(release)) => {
+            package_path.push(version);
+            package_path.push(release);
+            if !is_existing_dir(&package_path)? {
+                return Ok(package_list);
+            }
+
+            let active_target = PackageTarget::active_target();
+            if let Some(new_ident) = package_ident_from_dir(
+                &ident.origin,
+                &ident.name,
+                &version,
+                active_target,
+                &package_path,
+            ) {
+                package_list.push(new_ident.clone())
+            }
+        }
+    }
+    Ok(package_list)
+}
+
+/// Helper function for all_packages. Walks the directory at the given
+/// Path for origin directories and builds on the given package list
+/// by recursing into name, version, and release directories.
 fn walk_origins(path: &Path, packages: &mut Vec<PackageIdent>) -> Result<()> {
     for entry in fs::read_dir(path)? {
-        let origin = entry?;
-        if fs::metadata(origin.path())?.is_dir() {
-            walk_names(&origin, packages)?;
+        let origin_dir = entry?;
+        let origin_path = origin_dir.path();
+        if fs::metadata(&origin_path)?.is_dir() {
+            let origin = filename_from_entry(origin_dir);
+            walk_names(&origin, &origin_path, packages)?;
         }
     }
     Ok(())
 }
 
-/// Helper function for walk_origins. Walks the given origin DirEntry for name
-/// directories and recurses into them to find version and release directories.
-fn walk_names(origin: &DirEntry, packages: &mut Vec<PackageIdent>) -> Result<()> {
-    for name in fs::read_dir(origin.path())? {
-        let name = name?;
-        let origin = origin
-            .file_name()
-            .to_string_lossy()
-            .into_owned()
-            .to_string();
-        if fs::metadata(name.path())?.is_dir() {
-            walk_versions(&origin, &name, packages)?;
+/// Helper function for walk_origins. Walks the direcotry at the given
+/// Path for name directories and recurses into them to find version
+/// and release directories.
+fn walk_names(origin: &String, dir: &Path, packages: &mut Vec<PackageIdent>) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let name_dir = entry?;
+        let name_path = name_dir.path();
+        if fs::metadata(&name_path)?.is_dir() {
+            let name = filename_from_entry(name_dir);
+            walk_versions(&origin, &name, &name_path, packages)?;
         }
     }
     Ok(())
 }
 
-/// Helper function for walk_names. Walks the given name DirEntry for directories and recurses
-/// into them to find release directories.
-fn walk_versions(origin: &String, name: &DirEntry, packages: &mut Vec<PackageIdent>) -> Result<()> {
-    for version in fs::read_dir(name.path())? {
-        let version = version?;
-        let name = name.file_name().to_string_lossy().into_owned().to_string();
-        if fs::metadata(version.path())?.is_dir() {
-            walk_releases(origin, &name, &version, packages)?;
+/// Helper function for walk_names. Walks the directory at the given
+/// Path and recurses into them to find release directories.
+fn walk_versions(
+    origin: &String,
+    name: &String,
+    dir: &Path,
+    packages: &mut Vec<PackageIdent>,
+) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let version_dir = entry?;
+        let version_path = version_dir.path();
+        if fs::metadata(&version_path)?.is_dir() {
+            let version = filename_from_entry(version_dir);
+            walk_releases(origin, name, &version, &version_path, packages)?;
         }
     }
     Ok(())
 }
 
-/// Helper function for walk_versions. Walks the given release DirEntry for directories and
-/// recurses into them to find version directories. Finally, a Package struct is built and
-/// concatenated onto the given packages vector with the origin, name, version, and release of
-/// each.
+/// Helper function for walk_versions. Walks the directory at the
+/// given Path and constructs a Package struct if the directory is a
+/// valid package directory. Any resulting packages are pushed onto
+/// the given packages vector, assuming the given origin, name, and
+/// version.
 fn walk_releases(
     origin: &String,
     name: &String,
-    version: &DirEntry,
+    version: &String,
+    dir: &Path,
     packages: &mut Vec<PackageIdent>,
 ) -> Result<()> {
     let active_target = PackageTarget::active_target();
-
-    for entry in fs::read_dir(version.path())? {
-        let entry = entry?;
-        if let Some(path) = entry.path().file_name().and_then(|f| f.to_str()) {
-            if path.starts_with(INSTALL_TMP_PREFIX) {
-                debug!(
-                    "PackageInstall::walk_releases(): rejected PackageInstall candidate \
-                     because it matches installation temporary directory prefix: {}",
-                    path
-                );
-                continue;
+    for entry in fs::read_dir(dir)? {
+        let release_dir = entry?;
+        let release_path = release_dir.path();
+        if fs::metadata(&release_path)?.is_dir() {
+            if let Some(ident) =
+                package_ident_from_dir(origin, name, version, active_target, &release_path)
+            {
+                packages.push(ident)
             }
-        }
-
-        let metafile_content = read_metafile(entry.path(), &MetaFile::Target);
-        // If there is an error reading the target metafile, then skip the candidate
-        if let Err(e) = metafile_content {
-            debug!(
-                "PackageInstall::walk_releases(): rejected PackageInstall candidate \
-                 due to error reading TARGET metafile, found={}, reason={:?}",
-                entry.path().display(),
-                e,
-            );
-            continue;
-        }
-        // Any errors have been cleared, so unwrap is safe
-        let metafile_content = metafile_content.unwrap();
-        let install_target = PackageTarget::from_str(&metafile_content);
-        // If there is an error parsing the target as a valid PackageTarget, then skip the
-        // candidate
-        if let Err(e) = install_target {
-            debug!(
-                "PackageInstall::walk_releases(): rejected PackageInstall candidate \
-                 due to error parsing TARGET metafile as a valid PackageTarget, \
-                 found={}, reason={:?}",
-                entry.path().display(),
-                e,
-            );
-            continue;
-        }
-        // Any errors have been cleared, so unwrap is safe
-        let install_target = install_target.unwrap();
-
-        // Ensure that the installed package's target matches the active `PackageTarget`,
-        // otherwise skip the candidate
-        if active_target == &install_target {
-            let release = entry.file_name().to_string_lossy().into_owned().to_string();
-            let version = version
-                .file_name()
-                .to_string_lossy()
-                .into_owned()
-                .to_string();
-            let ident =
-                PackageIdent::new(origin.clone(), name.clone(), Some(version), Some(release));
-            packages.push(ident)
-        } else {
-            debug!(
-                "PackageInstall::walk_releases(): rejected PackageInstall candidate, \
-                 found={}, installed_target={}, active_target={}",
-                entry.path().display(),
-                install_target,
-                active_target,
-            );
         }
     }
     Ok(())
+}
+
+/// package_ident_from_dir returns a PackageIdent if the given
+/// path contains a valid package for the given active_target.
+///
+/// Returns None when
+///    - The directory is a temporary install directroy
+///    - An error occurs reading the package metadata
+///    - An error occurs reading the package target
+///    - The package target doesn't match the given active target
+fn package_ident_from_dir(
+    origin: &String,
+    name: &String,
+    version: &String,
+    active_target: &PackageTarget,
+    dir: &Path,
+) -> Option<PackageIdent> {
+    let release = if let Some(rel) = dir.file_name().and_then(|f| f.to_str()) {
+        rel
+    } else {
+        return None;
+    };
+
+    if release.starts_with(INSTALL_TMP_PREFIX) {
+        debug!(
+            "PackageInstall::package_ident_from_dir(): rejected PackageInstall candidate \
+             because it matches installation temporary directory prefix: {}",
+            dir.display()
+        );
+        return None;
+    }
+
+    let metafile_content = read_metafile(dir, &MetaFile::Target);
+    // If there is an error reading the target metafile, then skip the candidate
+    if let Err(e) = metafile_content {
+        debug!(
+            "PackageInstall::package_ident_from_dir(): rejected PackageInstall candidate \
+             due to error reading TARGET metafile, found={}, reason={:?}",
+            dir.display(),
+            e,
+        );
+        return None;
+    }
+
+    // Any errors have been cleared, so unwrap is safe
+    let metafile_content = metafile_content.unwrap();
+    let install_target = PackageTarget::from_str(&metafile_content);
+    // If there is an error parsing the target as a valid PackageTarget, then skip the
+    // candidate
+    if let Err(e) = install_target {
+        debug!(
+            "PackageInstall::package_ident_from_dir(): rejected PackageInstall candidate \
+             due to error parsing TARGET metafile as a valid PackageTarget, \
+             found={}, reason={:?}",
+            dir.display(),
+            e,
+        );
+        return None;
+    }
+    // Any errors have been cleared, so unwrap is safe
+    let install_target = install_target.unwrap();
+
+    // Ensure that the installed package's target matches the active `PackageTarget`,
+    // otherwise skip the candidate
+    if active_target == &install_target {
+        return Some(PackageIdent::new(
+            origin.clone(),
+            name.clone(),
+            Some(version.clone()),
+            Some(release.to_owned()),
+        ));
+    } else {
+        debug!(
+            "PackageInstall::package_ident_from_dir(): rejected PackageInstall candidate, \
+             found={}, installed_target={}, active_target={}",
+            dir.display(),
+            install_target,
+            active_target,
+        );
+        return None;
+    }
+}
+
+fn filename_from_entry(entry: fs::DirEntry) -> String {
+    return entry.file_name().to_string_lossy().into_owned().to_string();
+}
+
+fn is_existing_dir(path: &Path) -> Result<bool> {
+    match fs::metadata(&path) {
+        Err(err) => {
+            if err.kind() == io::ErrorKind::NotFound {
+                return Ok(false);
+            }
+            return Err(Error::from(err));
+        }
+        Ok(metadata) => return Ok(metadata.is_dir()),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously, the package load function was constructing a vector of all available packages on the system and then iterating the list to find a match to the ident.

This change uses the package ident to reduce the number of packages we need to consider. It assumes that packages will live at `/BASE/ORIGIN/NAME/VERSION/RELEASE`.

While it is unlikely that users will notice the improvement, avoiding the extra work seems straightforward enough.

The effects of this change can be seen by strace'ing the `hab pkg path` command on a system with a moderate number of packages installed.

Before:

```
> strace -f -c hab pkg path core/glibc
strace: Process 23858 attached
strace: Process 23859 attached
/hab/pkgs/core/glibc/2.27/20180608041157
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 21.34    0.002222          15       142        10 stat
 16.75    0.001744          10       164           getdents64
 15.03    0.001565          12       129           open
 11.75    0.001223           9       129           close
  9.72    0.001012         506         2           futex
  7.73    0.000805           6       127           fcntl
  7.10    0.000739           8        90           read
  3.25    0.000338           6        49           ioctl
  2.25    0.000234          21        11           munmap
  2.01    0.000209          17        12           mmap
  1.07    0.000111          12         9           sigaltstack
  0.36    0.000037          18         2           clone
  0.28    0.000029           5         5           brk
  0.28    0.000029           7         4           rt_sigprocmask
  0.23    0.000024          12         2           set_tid_address
  0.23    0.000024           8         3           getrandom
  0.18    0.000019          19         1           write
  0.17    0.000018           6         3           rt_sigaction
  0.13    0.000014           7         2           mprotect
  0.08    0.000008           8         1           geteuid
  0.08    0.000008           8         1           sched_getaffinity
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1         1 readlink
  0.00    0.000000           0         1           arch_prctl
------ ----------- ----------- --------- --------- ----------------
100.00    0.010412                   891        11 total
```

After:

```
> strace -f -c ../../../habitat/target/x86_64-unknown-linux-musl/release/hab pkg path core/glibc
strace: Process 23879 attached
strace: Process 23880 attached
/hab/pkgs/core/glibc/2.27/20180608041157
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 43.60    0.001369         684         2           futex
 22.58    0.000709          35        20        10 stat
  5.57    0.000175          14        12           mmap
  5.10    0.000160          14        11           munmap
  4.14    0.000130          14         9           sigaltstack
  3.22    0.000101          11         9           open
  2.39    0.000075           9         8           ioctl
  2.29    0.000072          12         6           getdents64
  2.17    0.000068           8         8           read
  1.82    0.000057           6         9           close
  1.46    0.000046           6         7           fcntl
  1.18    0.000037          18         2           mprotect
  1.15    0.000036          18         2           set_tid_address
  0.99    0.000031           7         4           rt_sigprocmask
  0.80    0.000025           8         3           getrandom
  0.61    0.000019           9         2           clone
  0.41    0.000013          13         1           write
  0.38    0.000012          12         1           geteuid
  0.16    0.000005           1         4           brk
  0.00    0.000000           0         3           rt_sigaction
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1         1 readlink
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           sched_getaffinity
------ ----------- ----------- --------- --------- ----------------
100.00    0.003140                   127        11 total
```

Signed-off-by: Steven Danna <steve@chef.io>