### PR TITLE
Add the ability to handle SIGHUP

### DIFF
--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -29,6 +29,7 @@ pub type SignalCode = libc::c_int;
 impl OsSignal for Signal {
     fn from_signal_code(code: SignalCode) -> Option<Signal> {
         match code {
+            libc::SIGHUP => Some(Signal::HUP),
             libc::SIGINT => Some(Signal::INT),
             libc::SIGILL => Some(Signal::ILL),
             libc::SIGABRT => Some(Signal::ABRT),

--- a/components/core/src/os/signals/mod.rs
+++ b/components/core/src/os/signals/mod.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 //! Contains the cross-platform signal behavior.
+// If signal handling ever becomes part of the rust stdlib, consider removing
+// our homespun implementation. Check for status of that here:
+// https://github.com/rust-lang/rfcs/issues/1368
 
 use os::process;
 


### PR DESCRIPTION
needed for [hab-sup controlled upgrade](https://github.com/habitat-sh/habitat/issues/5162)

Also, sneak in an unrelated comment about signal handling.
