### PR TITLE
Implement is_a_service method for PackageInstall

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -194,6 +194,18 @@ impl PackageInstall {
         }
     }
 
+    // hab-plan-build.sh only generates SVC_USER and SVC_GROUP files if it thinks a package is
+    // a service. It determines that by checking for the presence of a run hook file or a
+    // pkg_svc_run value. Therefore, if we can detect the presence of a SVC_USER file, we can
+    // consider this archive a service.
+    pub fn is_a_service(&self) -> bool {
+        match self.svc_user() {
+            Ok(None) => false,
+            Ok(_) => true,
+            _ => false,
+        }
+    }
+
     /// Determines whether or not this package has a runnable service.
     pub fn is_runnable(&self) -> bool {
         // Currently, a runnable package can be determined by checking if a `run` hook exists in


### PR DESCRIPTION
The implementation differs slightly from PackageArchive, due to the differences in how they handle svc_user.

svc_user is widely used through the code base and unifying the behavior for that function is something I think should be done, but would be too complex for this initial use case (habitat-sh/habitat#5298)

I also elected not to remove the `is_runnable` function until habitat-sh/habitat#5298 is merged. 

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>