### PR TITLE
Improve service group documentation to clarify optional @org part

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -431,7 +431,7 @@ impl error::Error for Error {
             }
             Error::InvalidPackageType(_) => "Unsupported package type supplied.",
             Error::InvalidServiceGroup(_) => {
-                "Service group strings must be in service.group format (example: redis.production)"
+                "Service group strings must be in service.group[@organization] format (example: redis.production or foo.default@bazcorp)"
             }
             Error::InvalidOrigin(_) => {
                 "Origins must begin with a lowercase letter or number.  \


### PR DESCRIPTION
Inspired by https://forums.habitat.sh/t/service-group-encryption-issue/780

See also https://github.com/habitat-sh/habitat/pull/5500

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>