### PR TITLE
make the default windows binlink dir /hab/bin

### DIFF
--- a/components/core/src/binlink.rs
+++ b/components/core/src/binlink.rs
@@ -15,6 +15,9 @@
 use env;
 
 /// Default Binlink Dir
+#[cfg(target_os = "windows")]
+pub const DEFAULT_BINLINK_DIR: &'static str = "/hab/bin";
+#[cfg(not(target_os = "windows"))]
 pub const DEFAULT_BINLINK_DIR: &'static str = "/bin";
 
 /// Binlink Dir Environment variable


### PR DESCRIPTION
This accompanies https://github.com/habitat-sh/habitat/pull/5513

Signed-off-by: mwrock <matt@mattwrock.com>