### PR TITLE
do not panic validating users and fail validation instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ version = "0.0.0"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -9,6 +9,9 @@ build = "build.rs"
 [build-dependencies]
 gcc = "0.3"
 
+[dependencies]
+log = "*"
+
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "*"
 widestring = "*"

--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -80,11 +80,14 @@ fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
     match Error::last_os_error().raw_os_error().unwrap() as u32 {
         ERROR_INSUFFICIENT_BUFFER => {}
         ERROR_NONE_MAPPED => return None,
-        _ => panic!(
-            "Error while looking up account for {}: {}",
-            name,
-            Error::last_os_error()
-        ),
+        _ => {
+            info!(
+                "Error while looking up account for {}: {}",
+                name,
+                Error::last_os_error()
+            );
+            return None;
+        }
     }
 
     let mut sid: Vec<u8> = Vec::with_capacity(sid_size as usize);
@@ -103,11 +106,12 @@ fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
         )
     };
     if ret == 0 {
-        panic!(
+        info!(
             "Failed to retrieve SID for {}: {}",
             name,
             Error::last_os_error()
         );
+        return None;
     }
     unsafe {
         domain.set_len(domain_size as usize);

--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -81,7 +81,7 @@ fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
         ERROR_INSUFFICIENT_BUFFER => {}
         ERROR_NONE_MAPPED => return None,
         _ => {
-            info!(
+            error!(
                 "Error while looking up account for {}: {}",
                 name,
                 Error::last_os_error()
@@ -106,7 +106,7 @@ fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
         )
     };
     if ret == 0 {
-        info!(
+        error!(
             "Failed to retrieve SID for {}: {}",
             name,
             Error::last_os_error()

--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate kernel32;
+#[macro_use]
+extern crate log;
 extern crate widestring;
 extern crate winapi;
 


### PR DESCRIPTION
fixes https://github.com/habitat-sh/habitat/issues/5258

There are some infrequent circumstances where calls to win32 `LookupAccountNameW` will fail for reasons other than the name was not mapped to a user. For example, there may be a brief period of time after a machine has been domain joined where a call might error in:
```
The trust relationship between this workstation and the primary domain failed. (os error 1789)
```
Rather then panicing, we should simply log the error and fail the lookup returning `None`.

Signed-off-by: mwrock <matt@mattwrock.com>