### PR TITLE
[ci,rustfmt] Formatting due to rustfmt 0.99.1-stable in Rust 1.29.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - language: rust
       env:
         - COMPONENTS=lib
-      rust: 1.28.0
+      rust: 1.29.0
       sudo: required
       addons:
         apt:

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -623,16 +623,19 @@ impl OpenOptions {
     }
 
     fn get_flags_and_attributes(&self) -> winapi::DWORD {
-        self.custom_flags | self.attributes | self.security_qos_flags
+        self.custom_flags
+            | self.attributes
+            | self.security_qos_flags
             | if self.security_qos_flags != 0 {
                 winapi::SECURITY_SQOS_PRESENT
             } else {
                 0
-            } | if self.create_new {
-            winapi::FILE_FLAG_OPEN_REPARSE_POINT
-        } else {
-            0
-        }
+            }
+            | if self.create_new {
+                winapi::FILE_FLAG_OPEN_REPARSE_POINT
+            } else {
+                0
+            }
     }
 }
 

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -103,18 +103,18 @@ impl PackageInstall {
                 Err(Error::PackageNotFound(ident.clone()))
             }
         } else {
-            let latest: Option<PackageIdent> = pl.iter().filter(|&p| p.satisfies(ident)).fold(
-                None,
-                |winner, b| match winner {
-                    Some(a) => match a.partial_cmp(&b) {
-                        Some(Ordering::Greater) => Some(a),
-                        Some(Ordering::Equal) => Some(a),
-                        Some(Ordering::Less) => Some(b.clone()),
-                        None => Some(a),
-                    },
-                    None => Some(b.clone()),
-                },
-            );
+            let latest: Option<PackageIdent> =
+                pl.iter()
+                    .filter(|&p| p.satisfies(ident))
+                    .fold(None, |winner, b| match winner {
+                        Some(a) => match a.partial_cmp(&b) {
+                            Some(Ordering::Greater) => Some(a),
+                            Some(Ordering::Equal) => Some(a),
+                            Some(Ordering::Less) => Some(b.clone()),
+                            None => Some(a),
+                        },
+                        None => Some(b.clone()),
+                    });
             if let Some(id) = latest {
                 Ok(PackageInstall {
                     installed_path: fs::pkg_install_path(&id, Some(&fs_root_path)),
@@ -347,7 +347,8 @@ impl PackageInstall {
         match self.read_metafile(MetaFile::Exports) {
             Ok(body) => {
                 let parsed_value = parse_key_value(&body);
-                let result = parsed_value.map_err(|_| Error::MetaFileMalformed(MetaFile::Exports))?;
+                let result =
+                    parsed_value.map_err(|_| Error::MetaFileMalformed(MetaFile::Exports))?;
                 Ok(result)
             }
             Err(Error::MetaFileNotFound(MetaFile::Exports)) => Ok(HashMap::new()),
@@ -1381,8 +1382,8 @@ core/bar=pub:core/publish sub:core/subscribe
                     pkg_prefix_for(&other_pkg_install).join("sbin"),
                 ].iter(),
             ).unwrap()
-                .to_string_lossy()
-                .as_ref(),
+            .to_string_lossy()
+            .as_ref(),
         );
 
         assert_eq!(
@@ -1623,8 +1624,8 @@ core/bar=pub:core/publish sub:core/subscribe
                 pkg_prefix_for(&pkg_install).join("bin"),
                 pkg_prefix_for(&other_pkg_install).join("sbin"),
             ]).unwrap()
-                .to_string_lossy()
-                .into_owned(),
+            .to_string_lossy()
+            .into_owned(),
         );
 
         assert_eq!(expected, pkg_install.environment_for_command().unwrap());

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -131,8 +131,7 @@ impl PkgEnv {
                             separator: None,
                         }
                     }
-                })
-                .collect(),
+                }).collect(),
         }
     }
 
@@ -311,7 +310,7 @@ port=front-end.port
             parse_key_value(&ENVIRONMENT).unwrap(),
             parse_key_value(&ENVIRONMENT_SEP).unwrap(),
         ).into_iter()
-            .collect::<Vec<_>>();
+        .collect::<Vec<_>>();
         // Sort the result by key, so we have a guarantee of order
         result.sort_by_key(|v| v.key.to_owned());
 

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -25,8 +25,8 @@ use hyper::http::h1::Http11Protocol;
 use hyper::net::HttpsConnector;
 use hyper_openssl::OpensslClient;
 use openssl::ssl::{
-    SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SslConnector, SslConnectorBuilder, SslMethod, SslOption,
-    SSL_OP_NO_COMPRESSION, SSL_VERIFY_NONE,
+    SslConnector, SslConnectorBuilder, SslMethod, SslOption, SSL_OP_NO_COMPRESSION,
+    SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SSL_VERIFY_NONE,
 };
 use url::Url;
 

--- a/support/ci/compile_libsodium.sh
+++ b/support/ci/compile_libsodium.sh
@@ -3,7 +3,7 @@ set -eu
 
 version=1.0.13
 nv=libsodium-$version
-source=https://download.libsodium.org/libsodium/releases/${nv}.tar.gz
+source=https://download.libsodium.org/libsodium/releases/old/${nv}.tar.gz
 prefix=$HOME/pkgs/libsodium/$version
 echo "LIBSODIUM PREFIX = ${prefix}"
 


### PR DESCRIPTION
https://blog.rust-lang.org/2018/09/13/Rust-1.29.html

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>