### PR TITLE
[win-users] Allow this crate to build on non-Windows platforms.

### DIFF
--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -14,11 +14,17 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+#[cfg(windows)]
 extern crate kernel32;
+#[cfg(windows)]
 #[macro_use]
 extern crate log;
+#[cfg(windows)]
 extern crate widestring;
+#[cfg(windows)]
 extern crate winapi;
 
+#[cfg(windows)]
 pub mod account;
+#[cfg(windows)]
 pub mod sid;


### PR DESCRIPTION
This change allows a developer to run `cargo build`/`cargo test`/etc.
from the root of this project, regardless of which platform they are
currently running.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>