### PR TITLE
make package list module public tro fix habitat dep code

### DIFF
--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -15,11 +15,10 @@
 pub mod archive;
 pub mod ident;
 pub mod install;
+pub mod list;
 pub mod metadata;
 pub mod plan;
 pub mod target;
-
-mod list;
 
 pub use self::archive::{FromArchive, PackageArchive};
 pub use self::ident::{Identifiable, PackageIdent};


### PR DESCRIPTION
This fixes a small break in the habitat repo that references `install::INSTALL_TMP_PREFIX` which was moved to the `list` module. Since that module is currently private habitat can't use it.

Signed-off-by: mwrock <matt@mattwrock.com>