### PR TITLE
Move back INSTALL_TMP_PREFIX to install.rs

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -35,6 +35,8 @@ use super::PackageTarget;
 #[cfg(test)]
 use std;
 
+pub const INSTALL_TMP_PREFIX: &'static str = ".hab-pkg-install";
+
 pub const DEFAULT_CFG_FILE: &'static str = "default.toml";
 const PATH_KEY: &'static str = "PATH";
 

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -17,12 +17,10 @@ use std::fs::DirEntry;
 use std::path::Path;
 use std::str::FromStr;
 
+use super::install::INSTALL_TMP_PREFIX;
 use super::metadata::{read_metafile, MetaFile};
 use super::{PackageIdent, PackageTarget};
-
 use error::Result;
-
-pub const INSTALL_TMP_PREFIX: &'static str = ".hab-pkg-install";
 
 /// Returns a list of package structs built from the contents of the given directory.
 pub fn all_packages(path: &Path) -> Result<Vec<PackageIdent>> {


### PR DESCRIPTION
This is getting used inside habitat core crate so should probably stay
where it was originally

Signed-off-by: James Casey <james@chef.io>