### PR TITLE
Move temp_package_directory over from `hab pkg install` logic

### DIFF
--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -27,6 +27,7 @@ serde = "*"
 serde_derive = "*"
 serde_json = "*"
 sodiumoxide = "0.0.16"
+tempdir = "*"
 time = "*"
 toml = { version = "*", default-features = false }
 typemap = "*"
@@ -44,7 +45,6 @@ windows-acl = "*"
 
 [dev-dependencies]
 hyper = "0.10"
-tempdir = "*"
 
 [features]
 default = []

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -131,6 +131,8 @@ pub enum Error {
     OpenDesktopFailed(String),
     /// Occurs when a suitable installed package cannot be found.
     PackageNotFound(package::PackageIdent),
+    /// Occurs where trying to unpack a package
+    PackageUnpackFailed(String),
     /// When an error occurs parsing an integer.
     ParseIntError(num::ParseIntError),
     /// Occurs when setting ownership or permissions on a file or directory fails.
@@ -314,6 +316,7 @@ impl fmt::Display for Error {
                     format!("Cannot find a release of package: {}", pkg)
                 }
             }
+            Error::PackageUnpackFailed(ref e) => format!("Package could not be unpacked. {}", e),
             Error::ParseIntError(ref e) => format!("{}", e),
             Error::PlanMalformed => format!("Failed to read or parse contents of Plan file"),
             Error::PermissionFailed(ref e) => format!("{}", e),
@@ -453,6 +456,7 @@ impl error::Error for Error {
             Error::NoOutboundAddr => "Failed to discover the outbound IP address",
             Error::OpenDesktopFailed(_) => "OpenDesktopW failed",
             Error::PackageNotFound(_) => "Cannot find a package",
+            Error::PackageUnpackFailed(_) => "Package could not be unpacked",
             Error::ParseIntError(_) => "Failed to parse an integer from a string!",
             Error::PermissionFailed(_) => "Failed to set permissions",
             Error::PlanMalformed => "Failed to read or parse contents of Plan file",

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -34,6 +34,7 @@ extern crate log;
 extern crate rand;
 extern crate regex;
 extern crate serde;
+extern crate tempdir;
 #[macro_use]
 extern crate serde_derive;
 
@@ -46,8 +47,6 @@ extern crate serde_json;
 extern crate serde_json;
 
 extern crate sodiumoxide;
-#[cfg(test)]
-extern crate tempdir;
 extern crate time;
 extern crate toml;
 extern crate typemap;


### PR DESCRIPTION
We need this in `uninstall` too.  moving it here gives a cleaner
abstraction around `INSTALL_TMP_PREFIX` which we can now make
private

Signed-off-by: James Casey <james@chef.io>