### PR TITLE
Make TMP_INSTALL_PREFIX pub again

### DIFF
--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -24,7 +24,7 @@ use error::{Error, Result};
 
 use tempdir::TempDir;
 
-const INSTALL_TMP_PREFIX: &'static str = ".hab-pkg-install";
+pub const INSTALL_TMP_PREFIX: &'static str = ".hab-pkg-install";
 
 /// Return a directory which can be used as a temp dir during package install/
 /// uninstall


### PR DESCRIPTION
Make the package list API changes work with current habitat repo
as well as new changes.

This can be made private when habitat-sh/habitat#5737 is merged

Signed-off-by: James Casey <james@chef.io>