### PR TITLE
 prepend fs_root to environment_for_command

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -197,6 +197,22 @@ where
     pkg_path
 }
 
+/// Given a linux style absolute path (prepended with '/') and a fs_root,
+/// this will "re-root" the path just under the fs_root. Otherwise returns
+/// the given path unchanged. Non-Windows platforms will always return the
+/// unchanged path.
+pub fn fs_rooted_path<T>(path: &PathBuf, fs_root: Option<T>) -> PathBuf
+where
+    T: AsRef<Path>,
+{
+    match fs_root {
+        Some(ref root) if path.starts_with("/") && cfg!(windows) => {
+            Path::new(root.as_ref()).join(path.strip_prefix("/").unwrap())
+        }
+        _ => path.to_path_buf(),
+    }
+}
+
 /// Returns the absolute path for a given command, if it exists, by searching the `PATH`
 /// environment variable.
 ///

--- a/components/core/src/util/win_perm.rs
+++ b/components/core/src/util/win_perm.rs
@@ -129,7 +129,7 @@ mod tests {
     use std::io::Write;
     use std::path::Path;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
     use winapi::um::winnt::FILE_ALL_ACCESS;
     use windows_acl::helper;
 
@@ -140,7 +140,10 @@ mod tests {
 
     #[test]
     fn set_permissions_ok_test() {
-        let tmp_dir = TempDir::new("foo").expect("create temp dir");
+        let tmp_dir = Builder::new()
+            .prefix("foo")
+            .tempdir()
+            .expect("create temp dir");
         let file_path = tmp_dir.path().join("test.txt");
         let mut tmp_file = File::create(&file_path).expect("create temp file");
         writeln!(tmp_file, "foobar123").expect("write temp file");


### PR DESCRIPTION
All upstream usages of `environment_for_command` end up prepending the `FS_ROOT`. I was about to add a [new usage](https://github.com/habitat-sh/habitat/pull/5813) and so it seems best to add it here.