### PR TITLE
moving some common functionality from habitat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,16 @@ version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "caps"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +174,11 @@ dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "failure"
@@ -228,6 +243,7 @@ version = "0.0.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -935,6 +951,7 @@ dependencies = [
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c71a98c48851ab3763bf766c4a5129e66a9b355f7ff1e93a68e725bbcd05221"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -943,6 +960,7 @@ dependencies = [
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64e9bc339e426139e02601fa69d101e96a92aee71b58bc01697ec2a63a5c9e68"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -37,6 +37,9 @@ url = "*"
 [target.'cfg(not(windows))'.dependencies]
 users = "*"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = "*"
+
 [target.'cfg(windows)'.dependencies]
 ctrlc = "*"
 habitat_win_users = { path = "../win-users" }

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -135,7 +135,7 @@ pub enum Error {
     PackageUnpackFailed(String),
     /// When an error occurs parsing an integer.
     ParseIntError(num::ParseIntError),
-    /// Occurs when setting ownership or permissions on a file or directory fails.
+    /// Occurs upon errors related to file or directory permissions.
     PermissionFailed(String),
     /// Error parsing the contents of a plan file were incomplete or malformed.
     PlanMalformed,
@@ -458,7 +458,7 @@ impl error::Error for Error {
             Error::PackageNotFound(_) => "Cannot find a package",
             Error::PackageUnpackFailed(_) => "Package could not be unpacked",
             Error::ParseIntError(_) => "Failed to parse an integer from a string!",
-            Error::PermissionFailed(_) => "Failed to set permissions",
+            Error::PermissionFailed(_) => "File system permissions error",
             Error::PlanMalformed => "Failed to read or parse contents of Plan file",
             Error::PrivilegeNotHeld => "Privilege not held to spawn process as different user",
             Error::RegexParse(_) => "Failed to parse a regular expression",

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate ansi_term;
+extern crate base64;
+#[cfg(target_os = "linux")]
+extern crate caps;
 extern crate crypto as rust_crypto;
 #[cfg(windows)]
 extern crate ctrlc;

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -12,10 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use caps::{self, CapSet, Capability};
 use std::path::PathBuf;
 
+use crate::error::{Error, Result};
 use crate::linux_users;
 use crate::linux_users::os::unix::{GroupExt, UserExt};
+
+/// This is currently the "master check" for whether the Supervisor
+/// can behave "as root".
+///
+/// All capabilities must be present. If we can run processes as other
+/// users, but can't change ownership, then the processes won't be
+/// able to access their files. Similar logic holds for the reverse.
+pub fn can_run_services_as_svc_user() -> bool {
+    has(Capability::CAP_SETUID) && has(Capability::CAP_SETGID) && has(Capability::CAP_CHOWN)
+}
+
+/// Helper function; does the current thread have `cap` in its
+/// effective capability set?
+fn has(cap: Capability) -> bool {
+    caps::has_cap(None, CapSet::Effective, cap).unwrap_or(false)
+}
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
     linux_users::get_user_by_name(owner).map(|u| u.uid())
@@ -66,4 +84,53 @@ pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
 
 pub fn root_level_account() -> String {
     "root".to_string()
+}
+
+/// This function checks to see if a user and group and if:
+///     a) we are root
+///     b) we are the specified user:group
+///     c) fail otherwise
+pub fn assert_pkg_user_and_group(user: &str, group: &str) -> Result<()> {
+    if let None = get_uid_by_name(user) {
+        return Err(Error::PermissionFailed(format!(
+            "Package requires user {} to exist, but it doesn't",
+            user
+        )));
+    }
+    if let None = get_gid_by_name(&group) {
+        return Err(Error::PermissionFailed(format!(
+            "Package requires group {} to exist, but it doesn't",
+            group
+        )));
+    }
+
+    let current_user = get_current_username();
+    let current_group = get_current_groupname();
+
+    if let None = current_user {
+        return Err(Error::PermissionFailed(
+            "Can't determine current user".to_string(),
+        ));
+    }
+
+    if let None = current_group {
+        return Err(Error::PermissionFailed(
+            "Can't determine current group".to_string(),
+        ));
+    }
+
+    let current_user = current_user.unwrap();
+    let current_group = current_group.unwrap();
+
+    if current_user == root_level_account() {
+        Ok(())
+    } else {
+        if current_user == user && current_group == group {
+            // ok, sup is running as svc_user/svc_group already
+            Ok(())
+        } else {
+            let msg = format!("Package must run as {}:{} or root", user, &group);
+            return Err(Error::PermissionFailed(msg));
+        }
+    }
 }

--- a/components/core/src/os/users/mod.rs
+++ b/components/core/src/os/users/mod.rs
@@ -18,16 +18,18 @@ mod windows;
 
 #[cfg(windows)]
 pub use self::windows::{
-    get_current_groupname, get_current_username, get_effective_uid, get_gid_by_name,
-    get_home_for_user, get_uid_by_name, root_level_account,
+    assert_pkg_user_and_group, can_run_services_as_svc_user, get_current_groupname,
+    get_current_username, get_effective_uid, get_gid_by_name, get_home_for_user, get_uid_by_name,
+    root_level_account,
 };
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub mod linux;
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 pub use self::linux::{
-    get_current_groupname, get_current_username, get_effective_gid, get_effective_groupname,
-    get_effective_uid, get_effective_username, get_gid_by_name, get_home_for_user, get_uid_by_name,
+    assert_pkg_user_and_group, can_run_services_as_svc_user, get_current_groupname,
+    get_current_username, get_effective_gid, get_effective_groupname, get_effective_uid,
+    get_effective_username, get_gid_by_name, get_home_for_user, get_uid_by_name,
     root_level_account,
 };

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -17,8 +17,14 @@ use std::path::PathBuf;
 
 use habitat_win_users::account::Account;
 
+use crate::error::{Error, Result};
+
 extern "C" {
     pub fn GetUserTokenStatus() -> u32;
+}
+
+pub fn can_run_services_as_svc_user() -> bool {
+    true
 }
 
 fn get_sid_by_name(name: &str) -> Option<String> {
@@ -64,6 +70,18 @@ pub fn root_level_account() -> String {
     env::var("COMPUTERNAME").unwrap().to_uppercase() + "$"
 }
 
+/// Windows does not have a concept of "group" in a Linux sense
+/// So we just validate the user
+pub fn assert_pkg_user_and_group(user: &str, _group: &str) -> Result<()> {
+    match get_uid_by_name(user) {
+        Some(_) => Ok(()),
+        None => Err(Error::PermissionFailed(format!(
+            "Package requires user {} to exist, but it doesn't",
+            user
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;
@@ -72,13 +90,17 @@ mod tests {
 
     #[test]
     fn downcase_current_username() {
+        let orig_user = get_current_username().unwrap();
         env::set_var("USERNAME", "uSer");
-        assert_eq!(get_current_username().unwrap(), "user")
+        assert_eq!(get_current_username().unwrap(), "user");
+        env::set_var("USERNAME", orig_user);
     }
 
     #[test]
     fn return_none_when_no_user() {
+        let orig_user = get_current_username().unwrap();
         env::remove_var("USERNAME");
-        assert_eq!(get_current_username(), None)
+        assert_eq!(get_current_username(), None);
+        env::set_var("USERNAME", orig_user);
     }
 }


### PR DESCRIPTION
This PR accompanies https://github.com/habitat-sh/habitat/pull/5866 which moves most of the hook and templating code from the supervisor into the `common` crate of the habitat repo. There was some functionality that also needed to be used commonly but seemed better suited here:

```
sup/src/fs.rs -> folded into /core/src/fs.rs
sup/src/sys/abilities -> folded into /core/src/os/users
sup/src/sys/user -> folded into /core/src/os/users
sup/src/manager/service/dir.rs -> folded into /core/src/fs.rs
```

Signed-off-by: mwrock <matt@mattwrock.com>