### PR TITLE
Add trait for converting numeric types to i64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(foreach component,$(ALL),$(eval $(call BUILD,$(component))))
 
 define UNIT
 unit-$1: ## executes the $1 component's unit test suite
-	cd components/$1 && cargo test
+	cd components/$1 && cargo test && cargo test --release
 .PHONY: unit-$1
 endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))


### PR DESCRIPTION
This is necessary for https://github.com/habitat-sh/habitat/pull/5986

![](https://media.giphy.com/media/l41YtZOb9EUABnuqA/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>