### PR TITLE
ToI64 has to be public if we actually want to use it elsewhere

### DIFF
--- a/components/core/src/util/mod.rs
+++ b/components/core/src/util/mod.rs
@@ -73,7 +73,7 @@ where
 }
 
 /// Provide a way to convert numeric types safely to i64
-trait ToI64 {
+pub trait ToI64 {
     fn to_i64(self) -> i64;
 }
 


### PR DESCRIPTION
![](https://media.giphy.com/media/3ov9jE3YKszddL2ak0/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>