### PR TITLE
[http-client] Lint and style updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,6 @@ name = "habitat_http_client"
 version = "0.0.0"
 dependencies = [
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -6,7 +6,6 @@ build = "build.rs"
 workspace = "../../"
 
 [dependencies]
-clippy = {version = "*", optional = true}
 base64 = "*"
 log = "*"
 httparse = "*"

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "habitat_http_client"
 version = "0.0.0"
+edition = "2018"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 build = "build.rs"
 workspace = "../../"

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -30,10 +30,10 @@ use openssl::ssl::{
 };
 use url::Url;
 
-use error::{Error, Result};
-use net::ProxyHttpsConnector;
-use proxy::{proxy_unless_domain_exempted, ProxyInfo};
-use ssl;
+use crate::error::{Error, Result};
+use crate::net::ProxyHttpsConnector;
+use crate::proxy::{proxy_unless_domain_exempted, ProxyInfo};
+use crate::ssl;
 
 // Read and write TCP socket timeout for Hyper/HTTP client calls.
 const CLIENT_SOCKET_RW_TIMEOUT_SEC: u64 = 120;

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -15,9 +15,9 @@
 use std::path::Path;
 use std::time::Duration;
 
-use hab_core::env;
-use hab_core::package::PackageTarget;
-use hab_core::util::sys;
+use habitat_core::env;
+use habitat_core::package::PackageTarget;
+use habitat_core::util::sys;
 use hyper::client::pool::{Config, Pool};
 use hyper::client::{Client as HyperClient, IntoUrl, RequestBuilder};
 use hyper::header::UserAgent;

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -208,7 +208,7 @@ impl ApiClient {
             return url;
         }
 
-        if url.path().ends_with("/") || path.starts_with("/") {
+        if url.path().ends_with('/') || path.starts_with('/') {
             url.set_path(&format!("{}{}", self.endpoint.path(), path));
         } else {
             url.set_path(&format!("{}/{}", self.endpoint.path(), path));

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -83,7 +83,7 @@ impl ApiClient {
             inner: new_hyper_client(&endpoint, fs_root_path)?,
             proxy: proxy_unless_domain_exempted(Some(&endpoint))?,
             target_scheme: endpoint.scheme().to_string(),
-            endpoint: endpoint,
+            endpoint,
             user_agent_header: user_agent(product, version)?,
         })
     }

--- a/components/http-client/src/error.rs
+++ b/components/http-client/src/error.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::io;
 use std::result;
 
-use hab_core;
+use habitat_core as hab_core;
 use hyper;
 use openssl::{self, ssl};
 use serde_json;

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate base64;
 extern crate habitat_core as hab_core;

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate base64;
-extern crate habitat_core as hab_core;
-extern crate httparse;
+// Used for `header!` macro which cannot be correctly resolved as it is exported as `hyper::header`
+// which is also a module name.
 #[macro_use]
 extern crate hyper;
-extern crate hyper_openssl;
+// Convenience importing of `debug!`/`info!` macros for entire crate.
 #[macro_use]
 extern crate log;
-extern crate openssl;
-extern crate serde;
-extern crate serde_json;
-extern crate url;
 
 mod api_client;
 mod error;
@@ -41,9 +36,9 @@ mod ssl {
     use std::path::Path;
     use std::str::FromStr;
 
-    use hab_core::env;
-    use hab_core::fs::cache_ssl_path;
-    use hab_core::package::{PackageIdent, PackageInstall};
+    use habitat_core::env;
+    use habitat_core::fs::cache_ssl_path;
+    use habitat_core::package::{PackageIdent, PackageInstall};
     use openssl::ssl::SslContextBuilder;
 
     use crate::error::Result;

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -25,14 +25,14 @@ extern crate serde;
 extern crate serde_json;
 extern crate url;
 
-pub mod api_client;
-pub mod error;
-pub mod net;
+mod api_client;
+mod error;
+mod net;
 pub mod proxy;
 pub mod util;
 
-pub use api_client::ApiClient;
-pub use error::{Error, Result};
+pub use crate::api_client::ApiClient;
+pub use crate::error::{Error, Result};
 
 #[cfg(not(target_os = "macos"))]
 mod ssl {
@@ -46,7 +46,7 @@ mod ssl {
     use hab_core::package::{PackageIdent, PackageInstall};
     use openssl::ssl::SslContextBuilder;
 
-    use error::Result;
+    use crate::error::Result;
 
     const CACERTS_PKG_IDENT: &'static str = "core/cacerts";
     const CACERT_PEM: &'static str = include_str!(concat!(env!("OUT_DIR"), "/cacert.pem"));
@@ -89,7 +89,7 @@ mod ssl {
 
     use openssl::ssl::SslContextBuilder;
 
-    use error::Result;
+    use crate::error::Result;
 
     pub fn set_ca(ctx: &mut SslContextBuilder, _fs_root_path: Option<&Path>) -> Result<()> {
         ctx.set_default_verify_paths()?;

--- a/components/http-client/src/net.rs
+++ b/components/http-client/src/net.rs
@@ -33,11 +33,11 @@ pub struct ProxyHttpsConnector<S: SslClient> {
 impl<S: SslClient> ProxyHttpsConnector<S> {
     /// Creates a new connection using the provided proxy server configuration and SSL
     /// implementation.
-    pub fn new(proxy: ProxyInfo, ssl: S) -> hyper::Result<Self> {
+    pub fn new(proxy: ProxyInfo, ssl_client: S) -> hyper::Result<Self> {
         Ok(ProxyHttpsConnector {
-            proxy: proxy,
+            proxy,
             proxy_connector: HttpConnector,
-            ssl_client: ssl,
+            ssl_client,
         })
     }
 }

--- a/components/http-client/src/net.rs
+++ b/components/http-client/src/net.rs
@@ -20,7 +20,7 @@ use hyper::method::Method;
 use hyper::net::{HttpConnector, HttpsStream, NetworkConnector, SslClient};
 use hyper::version::HttpVersion;
 
-use proxy::ProxyInfo;
+use crate::proxy::ProxyInfo;
 
 /// A connector that uses an HTTP proxy server (pass-through for plaintext and tunneled for SSL
 /// sessions).

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -448,9 +448,9 @@ pub fn proxy_unless_domain_exempted(for_domain: Option<&Url>) -> Result<Option<P
         None => "",
     };
     match env::var("no_proxy") {
-        Ok(domains) => process_no_proxy(for_domain, scheme, domains),
+        Ok(domains) => process_no_proxy(for_domain, scheme, &domains),
         _ => match env::var("NO_PROXY") {
-            Ok(domains) => process_no_proxy(for_domain, scheme, domains),
+            Ok(domains) => process_no_proxy(for_domain, scheme, &domains),
             _ => match scheme {
                 "https" => https_proxy(),
                 _ => http_proxy(),
@@ -462,7 +462,7 @@ pub fn proxy_unless_domain_exempted(for_domain: Option<&Url>) -> Result<Option<P
 fn process_no_proxy(
     for_domain: Option<&Url>,
     scheme: &str,
-    domains: String,
+    domains: &str,
 ) -> Result<Option<ProxyInfo>> {
     let domain = match for_domain {
         Some(url) => url.host_str().unwrap_or(""),

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -98,10 +98,7 @@ impl ProxyInfo {
             return Err(Error::UrlParseError(url::ParseError::InvalidPort));
         }
 
-        Ok(ProxyInfo {
-            url: url,
-            authorization: authorization,
-        })
+        Ok(ProxyInfo { url, authorization })
     }
 
     /// Returns the scheme for the proxy server.
@@ -156,10 +153,7 @@ pub struct ProxyBasicAuthorization {
 impl ProxyBasicAuthorization {
     /// Creates and returns a new `ProxyBasicAuthorization` with the given username and password.
     pub fn new(username: String, password: String) -> Self {
-        ProxyBasicAuthorization {
-            username: username,
-            password: password,
-        }
+        ProxyBasicAuthorization { username, password }
     }
 
     /// Returns a `String` containing the value for a `Proxy-Authorization` HTTP header.

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -18,7 +18,7 @@ use url::{self, Url};
 use base64;
 use hab_core::env;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 /// Configuration relating to an HTTP Proxy.
 ///

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -16,7 +16,7 @@ use url::percent_encoding::percent_decode;
 use url::{self, Url};
 
 use base64;
-use hab_core::env;
+use habitat_core::env;
 
 use crate::error::{Error, Result};
 

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -38,7 +38,6 @@ use crate::error::{Error, Result};
 ///     let url = Url::from_str("http://proxy.example.com:8001/").unwrap();
 ///     let proxy = ProxyInfo::new(url, None).unwrap();
 ///
-///     assert_eq!(proxy.scheme(), "http");
 ///     assert_eq!(proxy.host(), "proxy.example.com");
 ///     assert_eq!(proxy.port(), 8001);
 ///     assert!(proxy.authorization_header_value().is_none());
@@ -60,7 +59,6 @@ use crate::error::{Error, Result};
 ///     let authz = ProxyBasicAuthorization::new("foo".to_string(), "bar".to_string());
 ///     let proxy = ProxyInfo::new(url, Some(authz)).unwrap();
 ///
-///     assert_eq!(proxy.scheme(), "http");
 ///     assert_eq!(proxy.host(), "proxy.example.com");
 ///     assert_eq!(proxy.port(), 80);
 ///     assert_eq!(proxy.authorization_header_value().unwrap(), "Basic Zm9vOmJhcg==");
@@ -99,11 +97,6 @@ impl ProxyInfo {
         }
 
         Ok(ProxyInfo { url, authorization })
-    }
-
-    /// Returns the scheme for the proxy server.
-    pub fn scheme(&self) -> &str {
-        self.url.scheme()
     }
 
     /// Returns the host entry for the proxy server.
@@ -190,7 +183,6 @@ impl ProxyBasicAuthorization {
 /// std::env::set_var("http_proxy", "http://proxy.example.com:8001/");
 /// let info = proxy::http_proxy().unwrap().unwrap();
 ///
-/// assert_eq!(info.scheme(), "http");
 /// assert_eq!(info.host(), "proxy.example.com");
 /// assert_eq!(info.port(), 8001);
 /// assert!(info.authorization_header_value().is_none());
@@ -205,7 +197,6 @@ impl ProxyBasicAuthorization {
 /// std::env::set_var("http_proxy", "http://itsme:asecret@proxy.example.com");
 /// let info = proxy::http_proxy().unwrap().unwrap();
 ///
-/// assert_eq!(info.scheme(), "http");
 /// assert_eq!(info.host(), "proxy.example.com");
 /// assert_eq!(info.port(), 80);
 /// assert_eq!(info.authorization_header_value().unwrap(), "Basic aXRzbWU6YXNlY3JldA==");
@@ -276,7 +267,6 @@ pub fn http_proxy() -> Result<Option<ProxyInfo>> {
 /// std::env::set_var("https_proxy", "http://proxy.example.com:8001/");
 /// let info = proxy::https_proxy().unwrap().unwrap();
 ///
-/// assert_eq!(info.scheme(), "http");
 /// assert_eq!(info.host(), "proxy.example.com");
 /// assert_eq!(info.port(), 8001);
 /// assert!(info.authorization_header_value().is_none());
@@ -291,7 +281,6 @@ pub fn http_proxy() -> Result<Option<ProxyInfo>> {
 /// std::env::set_var("https_proxy", "http://itsme:asecret@proxy.example.com");
 /// let info = proxy::https_proxy().unwrap().unwrap();
 ///
-/// assert_eq!(info.scheme(), "http");
 /// assert_eq!(info.host(), "proxy.example.com");
 /// assert_eq!(info.port(), 80);
 /// assert_eq!(info.authorization_header_value().unwrap(), "Basic aXRzbWU6YXNlY3JldA==");
@@ -435,7 +424,6 @@ pub fn https_proxy() -> Result<Option<ProxyInfo>> {
 ///     let for_domain = Url::from_str("https://www.example.com").unwrap();
 ///     let info = proxy::proxy_unless_domain_exempted(Some(&for_domain)).unwrap().unwrap();
 ///
-///     assert_eq!(info.scheme(), "http");
 ///     assert_eq!(info.host(), "proxy.example.com");
 ///     assert_eq!(info.port(), 8001);
 ///     assert_eq!(info.authorization_header_value().unwrap(), "Basic aXRzbWU6YXNlY3JldA==");

--- a/components/http-client/src/proxy.rs
+++ b/components/http-client/src/proxy.rs
@@ -91,10 +91,10 @@ impl ProxyInfo {
                 return Err(Error::InvalidProxyValue(msg));
             }
         }
-        if let None = url.host_str() {
+        if url.host_str().is_none() {
             return Err(Error::UrlParseError(url::ParseError::EmptyHost));
         }
-        if let None = url.port_or_known_default() {
+        if url.port_or_known_default().is_none() {
             return Err(Error::UrlParseError(url::ParseError::InvalidPort));
         }
 

--- a/components/http-client/src/util.rs
+++ b/components/http-client/src/util.rs
@@ -18,7 +18,7 @@ use hyper::client::Response;
 use serde;
 use serde_json;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub fn decoded_response<T>(mut response: Response) -> Result<T>
 where


### PR DESCRIPTION
This set rolls up several changes described in the various commit messages, but the highlights include:

* Upgrading to Rust 2018 edition
* Removing some dead code and redundant `extern crate` declarations
* Removing the in-code tight coupling to Clippy in favor of using the now stable `clippy` Rustup component