### PR TITLE
Update to rust 2018 edition

### DIFF
--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "habitat_core"
 version = "0.0.0"
+edition = "2018"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>", "Steven Murawski <smurawski@chef.io>"]
 workspace = "../../"
 build = "build.rs"

--- a/components/core/src/binlink.rs
+++ b/components/core/src/binlink.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use env;
+use crate::env;
 
 /// Default Binlink Dir
 #[cfg(target_os = "windows")]

--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use env;
+use crate::env;
 
 pub const UNSTABLE_CHANNEL: &'static str = "unstable";
 pub const STABLE_CHANNEL: &'static str = "stable";

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use serde::de::DeserializeOwned;
 use toml;
 
-use error::Error;
+use crate::error::Error;
 
 pub trait ConfigFile: DeserializeOwned + Sized {
     type Error: StdError + From<Error>;

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -24,7 +24,7 @@ use sodiumoxide::crypto::sign;
 use super::hash;
 use super::keys::parse_name_with_rev;
 use super::{SigKeyPair, HART_FORMAT_VERSION, SIG_HASH_TYPE};
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 /// Generate and sign a package
 pub fn sign<P1: ?Sized, P2: ?Sized>(src: &P1, dst: &P2, pair: &SigKeyPair) -> Result<()>

--- a/components/core/src/crypto/dpapi.rs
+++ b/components/core/src/crypto/dpapi.rs
@@ -21,7 +21,7 @@ use winapi::shared::minwindef::DWORD;
 use winapi::um::dpapi;
 use winapi::um::wincrypt::CRYPTOAPI_BLOB;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 const COMPLEXITY: &'static [u8] = include_bytes!(concat!(env!("OUT_DIR"), "/hab-crypt"));
 

--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -21,7 +21,7 @@ use std::ptr;
 use hex;
 use libsodium_sys;
 
-use error::Result;
+use crate::error::Result;
 
 const BUF_SIZE: usize = 1024;
 

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -329,7 +329,7 @@ impl BoxKeyPair {
 
     // Return the metadata and encrypted text from a secret payload.
     // This is useful for services consuming an encrypted payload and need to decrypt it without having keys on disk
-    pub fn secret_metadata<'a>(payload: &'a [u8]) -> Result<BoxSecret> {
+    pub fn secret_metadata<'a>(payload: &'a [u8]) -> Result<BoxSecret<'_>> {
         let mut lines = str::from_utf8(payload)?.lines();
         let version = Self::box_key_format_version(lines.next())?;
         let sender = Self::box_key_sender(lines.next())?;

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -30,7 +30,7 @@ use super::{
     get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev, read_key_bytes,
     read_key_bytes_from_str, write_keypair_files, KeyPair, KeyType,
 };
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 #[derive(Debug)]
 pub struct BoxSecret<'a> {

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -34,7 +34,7 @@ use super::{
     SECRET_SYM_KEY_VERSION,
 };
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref NAME_WITH_REV_RE: Regex = Regex::new(r"\A(?P<name>.+)-(?P<rev>\d{14})\z").unwrap();
     static ref KEYFILE_RE: Regex =
         Regex::new(r"\A(?P<name>.+)-(?P<rev>\d{14})\.(?P<suffix>[a-z]+(\.[a-z]+)?)\z").unwrap();

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -26,7 +26,7 @@ use base64;
 use regex::Regex;
 use time;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 use super::{
     PUBLIC_BOX_KEY_VERSION, PUBLIC_KEY_SUFFIX, PUBLIC_SIG_KEY_VERSION, SECRET_BOX_KEY_SUFFIX,
@@ -571,7 +571,7 @@ fn write_keypair_files(
 
 #[cfg(not(windows))]
 fn set_permissions<T: AsRef<Path>>(path: T) -> Result<()> {
-    use util::posix_perm;
+    use crate::util::posix_perm;
 
     use super::KEY_PERMISSIONS;
 

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -580,7 +580,7 @@ fn set_permissions<T: AsRef<Path>>(path: T) -> Result<()> {
 
 #[cfg(windows)]
 fn set_permissions<T: AsRef<Path>>(path: T) -> Result<()> {
-    use util::win_perm;
+    use crate::util::win_perm;
 
     win_perm::harden_path(path.as_ref())
 }

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -51,7 +51,7 @@ enum KeyType {
 }
 
 impl fmt::Display for KeyType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             KeyType::Box => write!(f, "box"),
             KeyType::Sig => write!(f, "sig"),
@@ -67,7 +67,7 @@ pub enum PairType {
 }
 
 impl fmt::Display for PairType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             PairType::Public => write!(f, "public"),
             PairType::Secret => write!(f, "secret"),

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -29,7 +29,7 @@ use super::{
     get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev, read_key_bytes,
     write_keypair_files, KeyPair, KeyType, PairType, TmpKeyfile,
 };
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub type SigKeyPair = KeyPair<SigPublicKey, SigSecretKey>;
 

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -32,7 +32,7 @@ use crate::error::{Error, Result};
 pub type SymKey = KeyPair<(), SymSecretKey>;
 
 impl fmt::Debug for SymKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SymKey")
     }
 }

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -27,7 +27,7 @@ use super::{
     get_key_revisions, mk_key_filename, mk_revision_string, parse_name_with_rev, read_key_bytes,
     write_keypair_files, KeyPair, KeyType, PairType, TmpKeyfile,
 };
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub type SymKey = KeyPair<(), SymSecretKey>;
 

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -224,16 +224,16 @@
 //! <symkey_base64>
 //! ```
 
-use rust_crypto;
+use crate::rust_crypto;
 use std::path::{Path, PathBuf};
 
-use env as henv;
+use crate::env as henv;
 pub use sodiumoxide::init;
 
 pub use self::keys::box_key_pair::BoxKeyPair;
 pub use self::keys::sig_key_pair::SigKeyPair;
 pub use self::keys::sym_key::SymKey;
-use fs::cache_key_path;
+use crate::fs::cache_key_path;
 
 /// The suffix on the end of a public sig/box file
 pub static PUBLIC_KEY_SUFFIX: &'static str = "pub";
@@ -295,7 +295,7 @@ pub mod test_support {
 
     use time;
 
-    use error as herror;
+    use crate::error as herror;
 
     pub fn fixture(name: &str) -> PathBuf {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -27,7 +27,7 @@ use libarchive;
 use regex;
 use toml;
 
-use package::{self, Identifiable};
+use crate::package::{self, Identifiable};
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -169,7 +169,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
             Error::ArchiveError(ref err) => format!("{}", err),
             Error::BadBindingMode(ref value) => format!("Unknown binding mode '{}'", value),

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -110,7 +110,7 @@ impl fmt::Display for Event {
     // tool with a `"line exceeded maximum length"` error. This ignore should be removed when we
     // upgrade rustfmt and retry.
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
             Event::ProjectCreate { origin: _, package: _, account: _ } => "project-create",
             Event::PackageUpload { origin: _, package: _, version: _, release: _, target: _,

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -18,11 +18,11 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use users;
+use crate::users;
 
-use env as henv;
-use error::Result;
-use package::{Identifiable, PackageIdent, PackageInstall};
+use crate::env as henv;
+use crate::error::Result;
+use crate::package::{Identifiable, PackageIdent, PackageInstall};
 
 /// The default root path of the Habitat filesystem
 pub const ROOT_PATH: &'static str = "hab";

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -54,7 +54,7 @@ pub const SYSTEMDRIVE_ENVVAR: &'static str = "SYSTEMDRIVE";
 /// The file where user-defined configuration for each service is found.
 pub const USER_CONFIG_FILE: &'static str = "user.toml";
 
-lazy_static! {
+lazy_static::lazy_static! {
     /// The default filesystem root path.
     ///
     /// WARNING: On Windows this variable mutates on first call if an environment variable with

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -15,27 +15,25 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
-extern crate ansi_term;
-extern crate base64;
+use base64;
 extern crate crypto as rust_crypto;
 #[cfg(windows)]
 extern crate ctrlc;
-extern crate dirs;
-extern crate errno;
-extern crate hex;
-#[cfg(test)]
-extern crate hyper;
+use dirs;
+
+use hex;
+
 #[macro_use]
 extern crate lazy_static;
-extern crate libarchive;
-extern crate libc;
-extern crate libsodium_sys;
+use libarchive;
+use libc;
+use libsodium_sys;
 #[macro_use]
 extern crate log;
-extern crate rand;
-extern crate regex;
-extern crate serde;
-extern crate tempfile;
+
+use regex;
+use serde;
+
 #[macro_use]
 extern crate serde_derive;
 
@@ -47,11 +45,8 @@ extern crate serde_json;
 #[cfg(not(test))]
 extern crate serde_json;
 
-extern crate sodiumoxide;
-extern crate time;
-extern crate toml;
-extern crate typemap;
-extern crate url as extern_url;
+use time;
+use toml;
 
 #[cfg(not(windows))]
 extern crate users as linux_users;

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -84,8 +84,8 @@ pub mod util;
 
 use std::path::PathBuf;
 
-pub use os::filesystem;
-pub use os::users;
+pub use crate::os::filesystem;
+pub use crate::os::users;
 
 pub const AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
 

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -15,38 +15,15 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
-use base64;
 extern crate crypto as rust_crypto;
 #[cfg(windows)]
 extern crate ctrlc;
-use dirs;
 
-use hex;
-
-#[macro_use]
-extern crate lazy_static;
-use libarchive;
-use libc;
-use libsodium_sys;
 #[macro_use]
 extern crate log;
 
-use regex;
-use serde;
-
 #[macro_use]
 extern crate serde_derive;
-
-// This is a little gross, but we only need the macros in tests right
-// now.
-#[cfg(test)]
-#[macro_use]
-extern crate serde_json;
-#[cfg(not(test))]
-extern crate serde_json;
-
-use time;
-use toml;
 
 #[cfg(not(windows))]
 extern crate users as linux_users;
@@ -84,7 +61,7 @@ pub use crate::os::users;
 
 pub const AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
 
-lazy_static! {
+lazy_static::lazy_static! {
     pub static ref PROGRAM_NAME: String = {
         let arg0 = std::env::args().next().map(|p| PathBuf::from(p));
         arg0.as_ref()

--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 use libc::{self, pid_t};
 
 use super::{OsSignal, Signal};
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub type Pid = libc::pid_t;
 pub type SignalCode = libc::c_int;

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -28,7 +28,7 @@ pub use self::imp::*;
 
 pub trait OsSignal {
     fn os_signal(&self) -> SignalCode;
-    fn from_signal_code(SignalCode) -> Option<Signal>;
+    fn from_signal_code(_: SignalCode) -> Option<Signal>;
 }
 
 #[allow(non_snake_case)]

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -24,7 +24,7 @@ use winapi::um::processthreadsapi;
 use winapi::um::winnt::{HANDLE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE};
 
 use super::{OsSignal, Signal};
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 const STILL_ACTIVE: u32 = 259;
 

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -64,7 +64,7 @@ use winapi::um::winnt::{
     READ_CONTROL, WRITE_DAC,
 };
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 use habitat_win_users::sid::{self, Sid};
 
 use super::super::super::crypto::dpapi::decrypt;

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -70,7 +70,7 @@ use habitat_win_users::sid::{self, Sid};
 use super::super::super::crypto::dpapi::decrypt;
 use super::super::users::get_current_username;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref CREATE_PROCESS_LOCK: Mutex<()> = Mutex::new(());
 }
 

--- a/components/core/src/os/signals/mod.rs
+++ b/components/core/src/os/signals/mod.rs
@@ -17,7 +17,7 @@
 // our homespun implementation. Check for status of that here:
 // https://github.com/rust-lang/rfcs/issues/1368
 
-use os::process;
+use crate::os::process;
 
 #[allow(dead_code)]
 pub enum SignalEvent {

--- a/components/core/src/os/signals/unix.rs
+++ b/components/core/src/os/signals/unix.rs
@@ -23,7 +23,7 @@ use super::SignalEvent;
 
 static INIT: Once = ONCE_INIT;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref CAUGHT_SIGNALS: Mutex<VecDeque<SignalCode>> = Mutex::new(VecDeque::new());
 }
 

--- a/components/core/src/os/signals/unix.rs
+++ b/components/core/src/os/signals/unix.rs
@@ -17,7 +17,7 @@
 use std::collections::VecDeque;
 use std::sync::{Mutex, Once, ONCE_INIT};
 
-use os::process::{OsSignal, Signal, SignalCode};
+use crate::os::process::{OsSignal, Signal, SignalCode};
 
 use super::SignalEvent;
 

--- a/components/core/src/os/system/linux.rs
+++ b/components/core/src/os/system/linux.rs
@@ -18,8 +18,8 @@ use std::mem;
 use libc;
 
 use errno::errno;
-use error::{Error, Result};
-use os::system::Uname;
+use crate::error::{Error, Result};
+use crate::os::system::Uname;
 
 pub fn uname() -> Result<Uname> {
     unsafe { uname_libc() }

--- a/components/core/src/os/system/linux.rs
+++ b/components/core/src/os/system/linux.rs
@@ -17,9 +17,9 @@ use std::mem;
 
 use libc;
 
-use errno::errno;
 use crate::error::{Error, Result};
 use crate::os::system::Uname;
+use errno::errno;
 
 pub fn uname() -> Result<Uname> {
     unsafe { uname_libc() }

--- a/components/core/src/os/system/windows.rs
+++ b/components/core/src/os/system/windows.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use error::Result;
-use os::system::Uname;
+use crate::error::Result;
+use crate::os::system::Uname;
 
 pub fn uname() -> Result<Uname> {
     Ok(Uname {

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -14,8 +14,8 @@
 
 use std::path::PathBuf;
 
-use linux_users;
-use linux_users::os::unix::{GroupExt, UserExt};
+use crate::linux_users;
+use crate::linux_users::os::unix::{GroupExt, UserExt};
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
     linux_users::get_user_by_name(owner).map(|u| u.uid())

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -41,7 +41,7 @@ use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 use serde_json;
 
-use PROGRAM_NAME;
+use crate::PROGRAM_NAME;
 
 static mut VERBOSE: AtomicBool = ATOMIC_BOOL_INIT;
 // I am sorry this isn't named the other way; I can't get an atomic initializer that defaults to
@@ -300,7 +300,7 @@ mod tests {
     use ansi_term::Colour::{Cyan, White};
     use serde_json;
 
-    use PROGRAM_NAME;
+    use crate::PROGRAM_NAME;
 
     static LOGKEY: &'static str = "SOT";
 

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -164,7 +164,7 @@ impl<'a> Serialize for StructuredOutput<'a> {
 // essentially create a flag we check to see what output you want, then call a different formatting
 // function. Viola!
 impl<'a> fmt::Display for StructuredOutput<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.json.unwrap_or(is_json()) {
             // Our JSON serialization handles verbosity itself, and
             // color is ignored anyway, so there's no reason to check

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -350,7 +350,7 @@ mod tests {
 
         assert_eq!(
             actual,
-            json!({
+            serde_json::json!({
                 "preamble": "monkeys",
                 "logkey": LOGKEY,
                 "content": "I love monkeys"
@@ -369,7 +369,7 @@ mod tests {
 
         assert_eq!(
             actual,
-            json!({
+            serde_json::json!({
                 "preamble": "monkeys",
                 "logkey": LOGKEY,
                 "line": 1,
@@ -391,7 +391,7 @@ mod tests {
 
         assert_eq!(
             actual,
-            json!({
+            serde_json::json!({
                 "preamble": "monkeys",
                 "logkey": LOGKEY,
                 "content": "I love drab monkeys"

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -25,8 +25,8 @@ use regex::Regex;
 
 use super::metadata::{MetaFile, PackageType};
 use super::{Identifiable, PackageIdent, PackageTarget};
-use crypto::{artifact, hash};
-use error::{Error, Result};
+use crate::crypto::{artifact, hash};
+use crate::error::{Error, Result};
 
 lazy_static! {
     static ref METAFILE_REGXS: HashMap<MetaFile, Regex> = {

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -28,7 +28,7 @@ use super::{Identifiable, PackageIdent, PackageTarget};
 use crate::crypto::{artifact, hash};
 use crate::error::{Error, Result};
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref METAFILE_REGXS: HashMap<MetaFile, Regex> = {
         let mut map = HashMap::new();
         map.insert(

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -23,7 +23,7 @@ use regex::Regex;
 use crate::error::{Error, Result};
 use crate::package::PackageTarget;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref ORIGIN_NAME_RE: Regex =
         Regex::new(r"\A[a-z0-9][a-z0-9_-]*\z").expect("Unable to compile regex");
 }

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -130,7 +130,7 @@ impl PackageIdent {
     /// assert_eq!(it.next(), Some("myapp"));
     /// assert_eq!(it.next(), None);
     /// ```
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             ident: self,
             pos: 0,
@@ -203,7 +203,7 @@ impl Default for PackageIdent {
 }
 
 impl fmt::Display for PackageIdent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.version.is_some() && self.release.is_some() {
             write!(
                 f,

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -20,8 +20,8 @@ use std::str::FromStr;
 
 use regex::Regex;
 
-use error::{Error, Result};
-use package::PackageTarget;
+use crate::error::{Error, Result};
+use crate::package::PackageTarget;
 
 lazy_static! {
     static ref ORIGIN_NAME_RE: Regex =

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -653,7 +653,7 @@ impl PackageInstall {
 }
 
 impl fmt::Display for PackageInstall {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.ident)
     }
 }

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -27,8 +27,8 @@ use toml::Value;
 use super::list::package_list_for_ident;
 use super::metadata::{parse_key_value, read_metafile, Bind, BindMapping, MetaFile, PackageType};
 use super::{Identifiable, PackageIdent};
-use error::{Error, Result};
-use fs;
+use crate::error::{Error, Result};
+use crate::fs;
 
 #[cfg(test)]
 use super::PackageTarget;
@@ -667,7 +667,7 @@ mod test {
     use toml;
 
     use super::*;
-    use package::test_support::{fixture_path, testing_package_install};
+    use crate::package::test_support::{fixture_path, testing_package_install};
 
     /// Write the given contents into the specified metadata file for
     /// the package.

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use super::metadata::{read_metafile, MetaFile};
 use super::{PackageIdent, PackageTarget};
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 use tempfile::Builder;
 use tempfile::TempDir;
@@ -318,9 +318,9 @@ fn is_existing_dir(path: &Path) -> Result<bool> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use package::test_support::testing_package_install;
+    use crate::package::test_support::testing_package_install;
 
-    use fs;
+    use crate::fs;
     use std::fs::File;
     use tempfile::Builder;
 

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -23,8 +23,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::vec::IntoIter;
 
-use error::{Error, Result};
-use package::PackageIdent;
+use crate::error::{Error, Result};
+use crate::package::PackageIdent;
 
 #[cfg(not(windows))]
 const ENV_PATH_SEPARATOR: char = ':';

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -67,7 +67,7 @@ impl FromStr for Bind {
 }
 
 impl fmt::Display for Bind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let formatted_exports = self.exports.join(" ");
         write!(f, "[{}]={}", self.service, formatted_exports)
     }
@@ -195,7 +195,7 @@ pub enum MetaFile {
 }
 
 impl fmt::Display for MetaFile {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let id = match *self {
             MetaFile::BindMap => "BIND_MAP",
             MetaFile::Binds => "BINDS",
@@ -262,7 +262,7 @@ pub enum PackageType {
 }
 
 impl fmt::Display for PackageType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let id = match *self {
             PackageType::Standalone => "Standalone",
             PackageType::Composite => "Composite",

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -31,7 +31,7 @@ pub use self::target::PackageTarget;
 pub mod test_support {
     use super::metadata::MetaFile;
     use super::*;
-    use fs;
+    use crate::fs;
     use std::fs::{create_dir_all, File};
     use std::io::Write;
     use std::path::{Path, PathBuf};

--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -14,7 +14,7 @@
 
 use std::io::BufRead;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Plan {

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -363,7 +363,7 @@ impl PackageTarget {
     /// assert_eq!(it.next(), Some("linux"));
     /// assert_eq!(it.next(), None);
     /// ```
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             target: self,
             pos: 0,
@@ -414,7 +414,7 @@ impl PackageTarget {
 }
 
 impl fmt::Display for PackageTarget {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.as_str())
     }
 }

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -85,8 +85,8 @@ use std::str::FromStr;
 use regex::Regex;
 use serde;
 
-use error::Error;
-use util;
+use crate::error::Error;
+use crate::util;
 
 macro_rules! supported_package_targets {
     (

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -308,7 +308,7 @@ supported_package_targets! {
     ("x86_64-windows", X86_64_Windows, X86_64_WINDOWS, "x86_64", "windows");
 }
 
-lazy_static! {
+lazy_static::lazy_static! {
     /// A compiled regular expression that can parse the internal components of a `Type`.
     static ref TYPE_FROM_STR_RE: Regex = Regex::new(
         r"\A(?P<architecture>[a-z0-9_]+)-(?P<system>[a-z0-9_]+)(-(?P<variant>[a-z0-9_]+))?\z"

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use regex::Regex;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 lazy_static! {
     static ref SG_FROM_STR_RE: Regex =

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -61,7 +61,7 @@ impl Default for BindingMode {
 }
 
 impl fmt::Display for BindingMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = match *self {
             BindingMode::Relaxed => "relaxed",
             BindingMode::Strict => "strict",
@@ -213,7 +213,7 @@ impl DerefMut for ServiceGroup {
 }
 
 impl fmt::Display for ServiceGroup {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -326,7 +326,7 @@ impl DerefMut for ApplicationEnvironment {
 }
 
 impl fmt::Display for ApplicationEnvironment {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -364,7 +364,7 @@ impl AsRef<Duration> for HealthCheckInterval {
 }
 
 impl fmt::Display for HealthCheckInterval {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "({}s)", self.0.as_secs())
     }
 }

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -24,7 +24,7 @@ use regex::Regex;
 
 use crate::error::{Error, Result};
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref SG_FROM_STR_RE: Regex =
         Regex::new(r"\A((?P<application_environment>[^#@]+)#)?(?P<service>[^#@.]+)\.(?P<group>[^#@.]+)(@(?P<organization>[^#@.]+))?\z").unwrap();
 

--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use env;
+use crate::env;
 
 /// Default Builder URL environment variable
 pub const BLDR_URL_ENVVAR: &'static str = "HAB_BLDR_URL";

--- a/components/core/src/util/mod.rs
+++ b/components/core/src/util/mod.rs
@@ -42,7 +42,7 @@ where
     {
         type Value = T;
 
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("a string")
         }
 

--- a/components/core/src/util/posix_perm.rs
+++ b/components/core/src/util/posix_perm.rs
@@ -16,9 +16,9 @@ use libc::{self, c_char, c_int, mode_t};
 use std::ffi::CString;
 use std::path::Path;
 
-use users;
+use crate::users;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> Result<()> {
     debug!(
@@ -154,7 +154,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
-    use error::Error;
+    use crate::error::Error;
 
     #[test]
     fn chmod_ok_test() {

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -14,9 +14,9 @@
 
 use std::net::{IpAddr, UdpSocket};
 
-use error::Result;
+use crate::error::Result;
 
-pub use os::system::{uname, Uname};
+pub use crate::os::system::{uname, Uname};
 
 static GOOGLE_DNS: &'static str = "8.8.8.8:53";
 

--- a/components/core/src/util/win_perm.rs
+++ b/components/core/src/util/win_perm.rs
@@ -28,7 +28,7 @@ use windows_acl::helper;
 
 use habitat_win_users::account::Account;
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub struct PermissionEntry {
     pub account: Account,
@@ -136,7 +136,7 @@ mod tests {
     use habitat_win_users::account;
 
     use super::*;
-    use error::Error;
+    use crate::error::Error;
 
     #[test]
     fn set_permissions_ok_test() {

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "habitat_win_users"
 version = "0.0.0"
+edition = "2018"
 authors = ["Matt Wrock <matt@mattwrock.com>"]
 description = "Habitat library for win32 account api calls"
 workspace = "../../"

--- a/components/win-users/build.rs
+++ b/components/win-users/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+use gcc;
 
 #[cfg(windows)]
 fn main() {

--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -18,8 +18,6 @@
 #[macro_use]
 extern crate log;
 
-
-
 #[cfg(windows)]
 pub mod account;
 #[cfg(windows)]

--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -17,10 +17,8 @@
 #[cfg(windows)]
 #[macro_use]
 extern crate log;
-#[cfg(windows)]
-extern crate widestring;
-#[cfg(windows)]
-extern crate winapi;
+
+
 
 #[cfg(windows)]
 pub mod account;


### PR DESCRIPTION
Nearly all of these changes are automated. Any hand-fixes are broken out into separate commits.

See https://rust-lang-nursery.github.io/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html