### PR TITLE
Enable clippy in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
           - "$HOME/pkgs"
       before_script:
         - rustup component add rustfmt-preview
+        - rustup component add clippy
       before_install:
         - ./support/ci/compile_libsodium.sh
         - ./support/ci/compile_libarchive.sh
@@ -51,6 +52,7 @@ matrix:
       script:
         - ./support/ci/rust_tests.sh
         - ./support/ci/lint.sh
+        - make lint
 
 notifications:
   webhooks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,14 +115,6 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "clippy"
-version = "0.0.302"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +228,6 @@ version = "0.0.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -769,15 +760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,7 +937,6 @@ dependencies = [
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)" = "d911ee15579a3f50880d8c1d59ef6e79f9533127a3bd342462f5d584f5e8c294"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
@@ -1027,7 +1008,6 @@ dependencies = [
 "checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
-"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,90 @@ unit-$1: ## executes the $1 component's unit test suite
 endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
+# Lints we need to work through and decide as a team whether to allow or fix
+UNEXAMINED_LINTS = clippy::assign_op_pattern \
+                   clippy::blacklisted_name \
+                   clippy::block_in_if_condition_stmt \
+                   clippy::bool_comparison \
+                   clippy::cast_lossless \
+                   clippy::clone_on_copy \
+                   clippy::cmp_owned \
+                   clippy::collapsible_if \
+                   clippy::const_static_lifetime \
+                   clippy::cyclomatic_complexity \
+                   clippy::deref_addrof \
+                   clippy::expect_fun_call \
+                   clippy::for_kv_map \
+                   clippy::get_unwrap \
+                   clippy::identity_conversion \
+                   clippy::if_let_some_result \
+                   clippy::large_enum_variant \
+                   clippy::len_without_is_empty \
+                   clippy::len_zero \
+                   clippy::let_and_return \
+                   clippy::let_unit_value \
+                   clippy::map_clone \
+                   clippy::match_bool \
+                   clippy::match_ref_pats \
+                   clippy::module_inception \
+                   clippy::needless_bool \
+                   clippy::needless_collect \
+                   clippy::needless_pass_by_value \
+                   clippy::needless_range_loop \
+                   clippy::needless_return \
+                   clippy::new_ret_no_self \
+                   clippy::new_without_default \
+                   clippy::new_without_default_derive \
+                   clippy::ok_expect \
+                   clippy::op_ref \
+                   clippy::option_map_unit_fn \
+                   clippy::or_fun_call \
+                   clippy::println_empty_string \
+                   clippy::ptr_arg \
+                   clippy::question_mark \
+                   clippy::redundant_closure \
+                   clippy::redundant_field_names \
+                   clippy::redundant_pattern_matching \
+                   clippy::single_char_pattern \
+                   clippy::single_match \
+                   clippy::string_lit_as_bytes \
+                   clippy::too_many_arguments \
+                   clippy::toplevel_ref_arg \
+                   clippy::trivially_copy_pass_by_ref \
+                   clippy::unit_arg \
+                   clippy::unnecessary_operation \
+                   clippy::unreadable_literal \
+                   clippy::unused_label \
+                   clippy::unused_unit \
+                   clippy::useless_asref \
+                   clippy::useless_format \
+                   clippy::useless_let_if_seq \
+                   clippy::useless_vec \
+                   clippy::write_with_newline \
+                   clippy::wrong_self_convention \
+                   renamed_and_removed_lints
+
+# Lints we disagree with and choose to keep in our code with no warning
+ALLOWED_LINTS =
+
+# Known failing lints we want to receive warnings for, but not fail the build
+LINTS_TO_FIX =
+
+# Lints we don't expect to have in our code at all and want to avoid adding
+# even at the cost of failing the build
+DENIED_LINTS = clippy::correctness
+
+define LINT
+lint-$1: ## executes the $1 component's linter checks
+	$(run) sh -c 'cd components/$1 && cargo clippy --all-targets --tests $(CARGO_FLAGS) -- \
+	                                               $(addprefix -A ,$(UNEXAMINED_LINTS)) \
+	                                               $(addprefix -A ,$(ALLOWED_LINTS)) \
+	                                               $(addprefix -W ,$(LINTS_TO_FIX)) \
+	                                               $(addprefix -D ,$(DENIED_LINTS))'
+.PHONY: lint-$1
+endef
+$(foreach component,$(ALL),$(eval $(call LINT,$(component))))
+
 define CLEAN
 clean-$1: ## cleans the $1 component's project tree
 	cd components/$1 && cargo clean

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -12,7 +12,6 @@ gcc = "0.3"
 
 [dependencies]
 ansi_term = "*"
-clippy = {version = "*", optional = true}
 base64 = "*"
 dirs = "*"
 errno = "*"

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -61,19 +61,19 @@ pub fn get_archive_reader<P: AsRef<Path>>(src: &P) -> Result<BufReader<File>> {
     let mut empty_line = String::new();
 
     let mut reader = BufReader::new(f);
-    if reader.read_line(&mut your_format_version)? <= 0 {
+    if reader.read_line(&mut your_format_version)? == 0 {
         return Err(Error::CryptoError("Can't read format version".to_string()));
     }
-    if reader.read_line(&mut your_key_name)? <= 0 {
+    if reader.read_line(&mut your_key_name)? == 0 {
         return Err(Error::CryptoError("Can't read keyname".to_string()));
     }
-    if reader.read_line(&mut your_hash_type)? <= 0 {
+    if reader.read_line(&mut your_hash_type)? == 0 {
         return Err(Error::CryptoError("Can't read hash type".to_string()));
     }
-    if reader.read_line(&mut your_signature_raw)? <= 0 {
+    if reader.read_line(&mut your_signature_raw)? == 0 {
         return Err(Error::CryptoError("Can't read signature".to_string()));
     }
-    if reader.read_line(&mut empty_line)? <= 0 {
+    if reader.read_line(&mut empty_line)? == 0 {
         return Err(Error::CryptoError("Can't end of header".to_string()));
     }
     Ok(reader)
@@ -117,19 +117,19 @@ where
     let mut empty_line = String::new();
 
     let mut reader = BufReader::new(f);
-    if reader.read_line(&mut your_format_version)? <= 0 {
+    if reader.read_line(&mut your_format_version)? == 0 {
         return Err(Error::CryptoError("Can't read format version".to_string()));
     }
-    if reader.read_line(&mut your_key_name)? <= 0 {
+    if reader.read_line(&mut your_key_name)? == 0 {
         return Err(Error::CryptoError("Can't read keyname".to_string()));
     }
-    if reader.read_line(&mut your_hash_type)? <= 0 {
+    if reader.read_line(&mut your_hash_type)? == 0 {
         return Err(Error::CryptoError("Can't read hash type".to_string()));
     }
-    if reader.read_line(&mut your_signature_raw)? <= 0 {
+    if reader.read_line(&mut your_signature_raw)? == 0 {
         return Err(Error::CryptoError("Can't read signature".to_string()));
     }
-    if reader.read_line(&mut empty_line)? <= 0 {
+    if reader.read_line(&mut empty_line)? == 0 {
         return Err(Error::CryptoError("Can't end of header".to_string()));
     }
     let your_format_version = your_format_version.trim().to_string();
@@ -174,7 +174,7 @@ where
     };
     let pair = {
         let mut buffer = String::new();
-        if reader.read_line(&mut buffer)? <= 0 {
+        if reader.read_line(&mut buffer)? == 0 {
             return Err(Error::CryptoError(
                 "Corrupt payload, can't read origin key name".to_string(),
             ));
@@ -213,7 +213,7 @@ where
     };
     let _ = {
         let mut buffer = String::new();
-        if reader.read_line(&mut buffer)? <= 0 {
+        if reader.read_line(&mut buffer)? == 0 {
             return Err(Error::CryptoError(
                 "Corrupt payload, can't find end of header".to_string(),
             ));
@@ -261,7 +261,7 @@ pub fn artifact_signer<P: AsRef<Path>>(src: &P) -> Result<String> {
     };
     let name_with_rev = {
         let mut buffer = String::new();
-        if reader.read_line(&mut buffer)? <= 0 {
+        if reader.read_line(&mut buffer)? == 0 {
             return Err(Error::CryptoError(
                 "Corrupt payload, can't read origin key name".to_string(),
             ));
@@ -472,21 +472,21 @@ mod test {
         let f = BufReader::new(f);
         let mut lines = f.lines();
         corrupted
-            .write(lines.next().unwrap().unwrap().as_bytes())
+            .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // version
-        corrupted.write("\n".as_bytes()).unwrap();
+        corrupted.write_all("\n".as_bytes()).unwrap();
         corrupted
-            .write(lines.next().unwrap().unwrap().as_bytes())
+            .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // key
-        corrupted.write("\n".as_bytes()).unwrap();
+        corrupted.write_all("\n".as_bytes()).unwrap();
         corrupted
-            .write(lines.next().unwrap().unwrap().as_bytes())
+            .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // hash type
-        corrupted.write("\n".as_bytes()).unwrap();
+        corrupted.write_all("\n".as_bytes()).unwrap();
         corrupted
-            .write(lines.next().unwrap().unwrap().as_bytes())
+            .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // signature
-        corrupted.write("\n\n".as_bytes()).unwrap();
+        corrupted.write_all("\n\n".as_bytes()).unwrap();
         corrupted
             .write_all("payload-wont-match-signature".as_bytes())
             .unwrap(); // archive

--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -14,7 +14,6 @@
 
 use std::fs::File;
 use std::io::{BufReader, Read};
-use std::mem;
 use std::path::Path;
 use std::ptr;
 
@@ -40,9 +39,7 @@ where
 pub fn hash_string(data: &str) -> String {
     let mut out = [0u8; libsodium_sys::crypto_generichash_BYTES];
     let mut st = vec![0u8; unsafe { libsodium_sys::crypto_generichash_statebytes() }];
-    let pst = unsafe {
-        mem::transmute::<*mut u8, *mut libsodium_sys::crypto_generichash_state>(st.as_mut_ptr())
-    };
+    let pst = st.as_mut_ptr() as *mut libsodium_sys::crypto_generichash_state;
     unsafe {
         libsodium_sys::crypto_generichash_init(pst, ptr::null_mut(), 0, out.len());
         libsodium_sys::crypto_generichash_update(pst, data[..].as_ptr(), data.len() as u64);
@@ -54,9 +51,7 @@ pub fn hash_string(data: &str) -> String {
 pub fn hash_bytes(data: &[u8]) -> String {
     let mut out = [0u8; libsodium_sys::crypto_generichash_BYTES];
     let mut st = vec![0u8; unsafe { libsodium_sys::crypto_generichash_statebytes() }];
-    let pst = unsafe {
-        mem::transmute::<*mut u8, *mut libsodium_sys::crypto_generichash_state>(st.as_mut_ptr())
-    };
+    let pst = st.as_mut_ptr() as *mut libsodium_sys::crypto_generichash_state;
     unsafe {
         libsodium_sys::crypto_generichash_init(pst, ptr::null_mut(), 0, out.len());
         libsodium_sys::crypto_generichash_update(pst, data[..].as_ptr(), data.len() as u64);
@@ -68,9 +63,7 @@ pub fn hash_bytes(data: &[u8]) -> String {
 pub fn hash_reader(reader: &mut BufReader<File>) -> Result<String> {
     let mut out = [0u8; libsodium_sys::crypto_generichash_BYTES];
     let mut st = vec![0u8; unsafe { libsodium_sys::crypto_generichash_statebytes() }];
-    let pst = unsafe {
-        mem::transmute::<*mut u8, *mut libsodium_sys::crypto_generichash_state>(st.as_mut_ptr())
-    };
+    let pst = st.as_mut_ptr() as *mut libsodium_sys::crypto_generichash_state;
     unsafe {
         libsodium_sys::crypto_generichash_init(pst, ptr::null_mut(), 0, out.len());
     }

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -329,7 +329,7 @@ impl BoxKeyPair {
 
     // Return the metadata and encrypted text from a secret payload.
     // This is useful for services consuming an encrypted payload and need to decrypt it without having keys on disk
-    pub fn secret_metadata<'a>(payload: &'a [u8]) -> Result<BoxSecret<'_>> {
+    pub fn secret_metadata(payload: &[u8]) -> Result<BoxSecret<'_>> {
         let mut lines = str::from_utf8(payload)?.lines();
         let version = Self::box_key_format_version(lines.next())?;
         let sender = Self::box_key_sender(lines.next())?;
@@ -478,6 +478,7 @@ mod test {
 
     use super::super::super::test_support::*;
     use super::BoxKeyPair;
+    use super::*;
 
     static VALID_KEY: &'static str = "service-key-valid.default@acme-20160509181736.box.key";
     static VALID_PUB: &'static str = "service-key-valid.default@acme-20160509181736.pub";
@@ -494,7 +495,8 @@ mod test {
         assert_eq!(pair.public, None);
         match pair.public() {
             Ok(_) => panic!("Empty pair should not have a public key"),
-            Err(_) => assert!(true),
+            Err(Error::CryptoError(_)) => assert!(true),
+            e => panic!("Unexpected error: {:?}", e),
         }
         assert_eq!(pair.secret, None);
         match pair.secret() {
@@ -510,14 +512,14 @@ mod test {
         pair.to_pair_files(cache.path()).unwrap();
 
         assert_eq!(pair.name, "tnt.default@acme");
-        match pair.public() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a public key"),
-        }
-        match pair.secret() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a secret key"),
-        }
+        assert!(
+            pair.public().is_ok(),
+            "Generated pair should have a public key"
+        );
+        assert!(
+            pair.secret().is_ok(),
+            "Generated pair should have a secret key"
+        );
         assert!(cache
             .path()
             .join(format!("{}.pub", pair.name_with_rev()))
@@ -535,14 +537,14 @@ mod test {
         pair.to_pair_files(cache.path()).unwrap();
 
         assert_eq!(pair.name, "wecoyote");
-        match pair.public() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a public key"),
-        }
-        match pair.secret() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a secret key"),
-        }
+        assert!(
+            pair.public().is_ok(),
+            "Generated pair should have a public key"
+        );
+        assert!(
+            pair.secret().is_ok(),
+            "Generated pair should have a secret key"
+        );
         assert!(cache
             .path()
             .join(format!("{}.pub", pair.name_with_rev()))

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -492,7 +492,7 @@ pub fn parse_key_str(content: &str) -> Result<(PairType, String, String)> {
 fn read_key_bytes(keyfile: &Path) -> Result<Vec<u8>> {
     let mut f = File::open(keyfile)?;
     let mut s = String::new();
-    if f.read_to_string(&mut s)? <= 0 {
+    if f.read_to_string(&mut s)? == 0 {
         return Err(Error::CryptoError("Can't read key bytes".to_string()));
     }
     read_key_bytes_from_str(&s)

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -400,14 +400,14 @@ mod test {
         pair.to_pair_files(cache.path()).unwrap();
 
         assert_eq!(pair.name, "unicorn");
-        match pair.public() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a public key"),
-        }
-        match pair.secret() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a secret key"),
-        }
+        assert!(
+            pair.public().is_ok(),
+            "Generated pair should have a public key"
+        );
+        assert!(
+            pair.secret().is_ok(),
+            "Generated pair should have a public key"
+        );
         assert!(cache
             .path()
             .join(format!("{}.pub", pair.name_with_rev()))

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -472,14 +472,14 @@ mod test {
         pair.to_pair_files(cache.path()).unwrap();
 
         assert_eq!(pair.name, "beyonce");
-        match pair.public() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have an empty public key"),
-        }
-        match pair.secret() {
-            Ok(_) => assert!(true),
-            Err(_) => panic!("Generated pair should have a secret key"),
-        }
+        assert!(
+            pair.public().is_ok(),
+            "Generated pair should have an empty public key"
+        );
+        assert!(
+            pair.secret().is_ok(),
+            "Generated pair should have a secret key"
+        );
         assert!(cache
             .path()
             .join(format!("{}.sym.key", pair.name_with_rev()))

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -112,22 +112,15 @@ impl fmt::Display for Event {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
-            Event::ProjectCreate { origin: _, package: _, account: _ } => "project-create",
-            Event::PackageUpload { origin: _, package: _, version: _, release: _, target: _,
-                account: _ } => {
-                "package-upload"
-            }
-            Event::OriginKeyUpload { origin: _, version: _, account: _ } => "origin-key-upload",
-            Event::OriginSigningKeyUpload { origin: _, version: _, account: _ } => {
-                "origin-secret-key-upload"
-            }
-            Event::OriginInvitationSend { origin: _, user: _, id: _, account: _ } => {
-                "origin-invitation-send"
-            }
-            Event::OriginInvitationAccept { id: _, account: _ } => "origin-invitation-accept",
-            Event::OriginInvitationIgnore { id: _, account: _ } => "origin-invitation-ignore",
-            Event::JobCreate { package: _, account: _ } => "job-create",
-            Event::GithubAuthenticate { user: _, account: _ } => "github-authenticate",
+            Event::ProjectCreate { .. } => "project-create",
+            Event::PackageUpload { .. } => { "package-upload" }
+            Event::OriginKeyUpload { .. } => "origin-key-upload",
+            Event::OriginSigningKeyUpload { .. } => { "origin-secret-key-upload" }
+            Event::OriginInvitationSend { .. } => { "origin-invitation-send" }
+            Event::OriginInvitationAccept { .. } => "origin-invitation-accept",
+            Event::OriginInvitationIgnore { .. } => "origin-invitation-ignore",
+            Event::JobCreate { .. } => "job-create",
+            Event::GithubAuthenticate { .. } => "github-authenticate",
         };
 
         write!(f, "{}", msg)
@@ -135,6 +128,7 @@ impl fmt::Display for Event {
 }
 
 impl Serialize for Event {
+    #[allow(clippy::many_single_char_names)]
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-
 extern crate crypto as rust_crypto;
 #[cfg(windows)]
 extern crate ctrlc;

--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
 
 #[cfg(windows)]
 #[macro_use]


### PR DESCRIPTION
TravisCI will now run clippy and generate warnings for lints specified as `LINTS_TO_FIX` and errors for `DENIED_LINTS` as configured in the Makefile. All `clippy::correctness` lints have also been fixed as part of this PR. See https://rust-lang.github.io/rust-clippy/master/index.html.

Also remove unnecessary dependencies and fix up the make lint command.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>