### PR TITLE
Replace Strings and &strs with type-safe habitat_core::ChannelIdent type

### DIFF
--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -90,10 +90,6 @@ impl ChannelIdent {
         crate::env::var(key).map(ChannelIdent)
     }
 
-    pub fn from(s: &str) -> Self {
-        ChannelIdent(s.to_string())
-    }
-
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
@@ -118,6 +114,18 @@ impl ChannelIdent {
     /// Helper function for Builder dynamic channels
     pub fn bldr_name(id: u64) -> String {
         format!("bldr-{}", id)
+    }
+}
+
+impl From<&str> for ChannelIdent {
+    fn from(s: &str) -> Self {
+        ChannelIdent(s.to_string())
+    }
+}
+
+impl From<String> for ChannelIdent {
+    fn from(s: String) -> Self {
+        ChannelIdent(s)
     }
 }
 

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -107,7 +107,7 @@ impl ChannelIdent {
             env::var(Self::LEGACY_ENVVAR)
                 .ok()
                 .and_then(|c| Some(c.to_string()))
-                .unwrap_or(Self::STABLE.to_string()),
+                .unwrap_or_else(|| Self::STABLE.to_string()),
         )
     }
 }

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -110,11 +110,6 @@ impl ChannelIdent {
                 .unwrap_or(Self::STABLE.to_string()),
         )
     }
-
-    /// Helper function for Builder dynamic channels
-    pub fn bldr_name(id: u64) -> String {
-        format!("bldr-{}", id)
-    }
 }
 
 impl From<&str> for ChannelIdent {


### PR DESCRIPTION
The potential for using `Default::default()` instead of `channel::default()` when the type representing a channel is a `&str` or `String` is a nasty latent error that the compiler will not find. To avoid it, we should use a proper type to represent channel names.

There are corresponding changes to the [habitat](https://github.com/habitat-sh/habitat/pull/6074) and [builder](https://github.com/habitat-sh/builder/pull/881) repos that must be merged after this. After that, [channel.rs](https://github.com/habitat-sh/core/blob/master/components/core/src/channel.rs) can be removed entirely.