### PR TITLE
Enable core Clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
-				   clippy::map_clone \
 				   clippy::match_bool \
 				   clippy::match_ref_pats \
 				   clippy::module_inception \
@@ -129,6 +128,8 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::len_zero \
 			   clippy::let_and_return \
 			   clippy::let_unit_value \
+			   clippy::map_clone \
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::useless_vec \
 				   clippy::write_with_newline \
 				   clippy::wrong_self_convention \
 				   renamed_and_removed_lints
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::useless_asref \
 			   clippy::useless_format \
 			   clippy::useless_let_if_seq \
+			   clippy::useless_vec \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::useless_format \
 				   clippy::useless_let_if_seq \
 				   clippy::useless_vec \
 				   clippy::write_with_newline \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::unused_label \
 			   clippy::unused_unit \
 			   clippy::useless_asref \
+			   clippy::useless_format \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::unreadable_literal \
 				   clippy::unused_label \
 				   clippy::unused_unit \
 				   clippy::useless_asref \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::toplevel_ref_arg \
 			   clippy::unit_arg \
 			   clippy::unnecessary_operation \
+			   clippy::unreadable_literal \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_without_default_derive \
 				   clippy::question_mark \
 				   clippy::redundant_field_names \
-				   clippy::single_char_pattern \
 				   clippy::single_match \
 				   clippy::string_lit_as_bytes \
 				   clippy::too_many_arguments \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::ptr_arg \
 			   clippy::redundant_closure \
 			   clippy::redundant_pattern_matching \
+			   clippy::single_char_pattern \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::useless_asref \
 				   clippy::useless_format \
 				   clippy::useless_let_if_seq \
 				   clippy::useless_vec \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::unreadable_literal \
 			   clippy::unused_label \
 			   clippy::unused_unit \
+			   clippy::useless_asref \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
-				   clippy::len_zero \
 				   clippy::let_and_return \
 				   clippy::let_unit_value \
 				   clippy::map_clone \
@@ -129,6 +128,8 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::get_unwrap \
 			   clippy::identity_conversion \
 			   clippy::if_let_some_result \
+			   clippy::len_zero \
+
 
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::unused_unit \
 				   clippy::useless_asref \
 				   clippy::useless_format \
 				   clippy::useless_let_if_seq \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::unnecessary_operation \
 			   clippy::unreadable_literal \
 			   clippy::unused_label \
+			   clippy::unused_unit \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
-				   clippy::println_empty_string \
 				   clippy::ptr_arg \
 				   clippy::question_mark \
 				   clippy::redundant_closure \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::op_ref \
 			   clippy::option_map_unit_fn \
 			   clippy::or_fun_call \
+			   clippy::println_empty_string \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::clone_on_copy \
-				   clippy::cmp_owned \
+UNEXAMINED_LINTS = clippy::cmp_owned \
 				   clippy::collapsible_if \
 				   clippy::const_static_lifetime \
 				   clippy::cyclomatic_complexity \
@@ -128,6 +127,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::block_in_if_condition_stmt \
 			   clippy::bool_comparison \
 			   clippy::cast_lossless \
+			   clippy::clone_on_copy \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
 				   clippy::module_inception \
-				   clippy::needless_bool \
 				   clippy::needless_collect \
 				   clippy::needless_pass_by_value \
 				   clippy::needless_range_loop \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::map_clone \
 			   clippy::match_bool \
 			   clippy::match_ref_pats \
+			   clippy::needless_bool \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_without_default_derive \
 				   clippy::question_mark \
 				   clippy::redundant_field_names \
-				   clippy::string_lit_as_bytes \
 				   clippy::too_many_arguments \
 				   clippy::toplevel_ref_arg \
 				   clippy::trivially_copy_pass_by_ref \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::redundant_pattern_matching \
 			   clippy::single_char_pattern \
 			   clippy::single_match \
+			   clippy::string_lit_as_bytes \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::question_mark \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
-				   clippy::toplevel_ref_arg \
 				   clippy::trivially_copy_pass_by_ref \
 				   clippy::unit_arg \
 				   clippy::unnecessary_operation \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::single_char_pattern \
 			   clippy::single_match \
 			   clippy::string_lit_as_bytes \
+			   clippy::toplevel_ref_arg \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-				   clippy::identity_conversion \
 				   clippy::if_let_some_result \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::expect_fun_call \
 			   clippy::for_kv_map \
 			   clippy::get_unwrap \
+			   clippy::identity_conversion \
 
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::unnecessary_operation \
 				   clippy::unreadable_literal \
 				   clippy::unused_label \
 				   clippy::unused_unit \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::string_lit_as_bytes \
 			   clippy::toplevel_ref_arg \
 			   clippy::unit_arg \
+			   clippy::unnecessary_operation \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::cmp_owned \
-				   clippy::collapsible_if \
+UNEXAMINED_LINTS = clippy::collapsible_if \
 				   clippy::const_static_lifetime \
 				   clippy::cyclomatic_complexity \
 				   clippy::deref_addrof \
@@ -128,6 +127,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::bool_comparison \
 			   clippy::cast_lossless \
 			   clippy::clone_on_copy \
+			   clippy::cmp_owned \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
-				   clippy::option_map_unit_fn \
 				   clippy::or_fun_call \
 				   clippy::println_empty_string \
 				   clippy::ptr_arg \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::needless_range_loop \
 			   clippy::ok_expect \
 			   clippy::op_ref \
+			   clippy::option_map_unit_fn \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::bool_comparison \
-				   clippy::cast_lossless \
+UNEXAMINED_LINTS = clippy::cast_lossless \
 				   clippy::clone_on_copy \
 				   clippy::cmp_owned \
 				   clippy::collapsible_if \
@@ -128,6 +127,7 @@ LINTS_TO_FIX =
 DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::blacklisted_name \
 			   clippy::block_in_if_condition_stmt \
+			   clippy::bool_comparison \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::blacklisted_name \
-				   clippy::block_in_if_condition_stmt \
+UNEXAMINED_LINTS = clippy::block_in_if_condition_stmt \
 				   clippy::bool_comparison \
 				   clippy::cast_lossless \
 				   clippy::clone_on_copy \
@@ -128,7 +127,8 @@ LINTS_TO_FIX =
 # Lints we don't expect to have in our code at all and want to avoid adding
 # even at the cost of failing the build
 DENIED_LINTS = clippy::assign_op_pattern \
-			   clippy::correctness
+			   clippy::blacklisted_name \
+			   clippy::correctness \
 
 define LINT
 lint-$1: ## executes the $1 component's linter checks

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-				   clippy::get_unwrap \
 				   clippy::identity_conversion \
 				   clippy::if_let_some_result \
 				   clippy::large_enum_variant \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::deref_addrof \
 			   clippy::expect_fun_call \
 			   clippy::for_kv_map \
+			   clippy::get_unwrap \
 
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::cast_lossless \
-				   clippy::clone_on_copy \
+UNEXAMINED_LINTS = clippy::clone_on_copy \
 				   clippy::cmp_owned \
 				   clippy::collapsible_if \
 				   clippy::const_static_lifetime \
@@ -128,6 +127,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::blacklisted_name \
 			   clippy::block_in_if_condition_stmt \
 			   clippy::bool_comparison \
+			   clippy::cast_lossless \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-				   clippy::expect_fun_call \
 				   clippy::for_kv_map \
 				   clippy::get_unwrap \
 				   clippy::identity_conversion \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::const_static_lifetime \
 			   clippy::correctness \
 			   clippy::deref_addrof \
+			   clippy::expect_fun_call \
 
 define LINT
 lint-$1: ## executes the $1 component's linter checks

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::const_static_lifetime \
-				   clippy::cyclomatic_complexity \
+UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::deref_addrof \
 				   clippy::expect_fun_call \
 				   clippy::for_kv_map \
@@ -128,6 +127,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::clone_on_copy \
 			   clippy::cmp_owned \
 			   clippy::collapsible_if \
+			   clippy::const_static_lifetime \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
-				   clippy::ok_expect \
 				   clippy::op_ref \
 				   clippy::option_map_unit_fn \
 				   clippy::or_fun_call \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::needless_bool \
 			   clippy::needless_collect \
 			   clippy::needless_range_loop \
+			   clippy::ok_expect \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::unit_arg \
 				   clippy::unnecessary_operation \
 				   clippy::unreadable_literal \
 				   clippy::unused_label \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::single_match \
 			   clippy::string_lit_as_bytes \
 			   clippy::toplevel_ref_arg \
+			   clippy::unit_arg \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,67 +58,66 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::assign_op_pattern \
-                   clippy::blacklisted_name \
-                   clippy::block_in_if_condition_stmt \
-                   clippy::bool_comparison \
-                   clippy::cast_lossless \
-                   clippy::clone_on_copy \
-                   clippy::cmp_owned \
-                   clippy::collapsible_if \
-                   clippy::const_static_lifetime \
-                   clippy::cyclomatic_complexity \
-                   clippy::deref_addrof \
-                   clippy::expect_fun_call \
-                   clippy::for_kv_map \
-                   clippy::get_unwrap \
-                   clippy::identity_conversion \
-                   clippy::if_let_some_result \
-                   clippy::large_enum_variant \
-                   clippy::len_without_is_empty \
-                   clippy::len_zero \
-                   clippy::let_and_return \
-                   clippy::let_unit_value \
-                   clippy::map_clone \
-                   clippy::match_bool \
-                   clippy::match_ref_pats \
-                   clippy::module_inception \
-                   clippy::needless_bool \
-                   clippy::needless_collect \
-                   clippy::needless_pass_by_value \
-                   clippy::needless_range_loop \
-                   clippy::needless_return \
-                   clippy::new_ret_no_self \
-                   clippy::new_without_default \
-                   clippy::new_without_default_derive \
-                   clippy::ok_expect \
-                   clippy::op_ref \
-                   clippy::option_map_unit_fn \
-                   clippy::or_fun_call \
-                   clippy::println_empty_string \
-                   clippy::ptr_arg \
-                   clippy::question_mark \
-                   clippy::redundant_closure \
-                   clippy::redundant_field_names \
-                   clippy::redundant_pattern_matching \
-                   clippy::single_char_pattern \
-                   clippy::single_match \
-                   clippy::string_lit_as_bytes \
-                   clippy::too_many_arguments \
-                   clippy::toplevel_ref_arg \
-                   clippy::trivially_copy_pass_by_ref \
-                   clippy::unit_arg \
-                   clippy::unnecessary_operation \
-                   clippy::unreadable_literal \
-                   clippy::unused_label \
-                   clippy::unused_unit \
-                   clippy::useless_asref \
-                   clippy::useless_format \
-                   clippy::useless_let_if_seq \
-                   clippy::useless_vec \
-                   clippy::write_with_newline \
-                   clippy::wrong_self_convention \
-                   renamed_and_removed_lints
+UNEXAMINED_LINTS = clippy::blacklisted_name \
+				   clippy::block_in_if_condition_stmt \
+				   clippy::bool_comparison \
+				   clippy::cast_lossless \
+				   clippy::clone_on_copy \
+				   clippy::cmp_owned \
+				   clippy::collapsible_if \
+				   clippy::const_static_lifetime \
+				   clippy::cyclomatic_complexity \
+				   clippy::deref_addrof \
+				   clippy::expect_fun_call \
+				   clippy::for_kv_map \
+				   clippy::get_unwrap \
+				   clippy::identity_conversion \
+				   clippy::if_let_some_result \
+				   clippy::large_enum_variant \
+				   clippy::len_without_is_empty \
+				   clippy::len_zero \
+				   clippy::let_and_return \
+				   clippy::let_unit_value \
+				   clippy::map_clone \
+				   clippy::match_bool \
+				   clippy::match_ref_pats \
+				   clippy::module_inception \
+				   clippy::needless_bool \
+				   clippy::needless_collect \
+				   clippy::needless_pass_by_value \
+				   clippy::needless_range_loop \
+				   clippy::needless_return \
+				   clippy::new_ret_no_self \
+				   clippy::new_without_default \
+				   clippy::new_without_default_derive \
+				   clippy::ok_expect \
+				   clippy::op_ref \
+				   clippy::option_map_unit_fn \
+				   clippy::or_fun_call \
+				   clippy::println_empty_string \
+				   clippy::ptr_arg \
+				   clippy::question_mark \
+				   clippy::redundant_closure \
+				   clippy::redundant_field_names \
+				   clippy::redundant_pattern_matching \
+				   clippy::single_char_pattern \
+				   clippy::single_match \
+				   clippy::string_lit_as_bytes \
+				   clippy::too_many_arguments \
+				   clippy::toplevel_ref_arg \
+				   clippy::trivially_copy_pass_by_ref \
+				   clippy::unit_arg \
+				   clippy::unnecessary_operation \
+				   clippy::unreadable_literal \
+				   clippy::unused_label \
+				   clippy::unused_unit \
+				   clippy::useless_asref \
+				   clippy::useless_format \
+				   clippy::useless_let_if_seq \
+				   clippy::useless_vec \
+				   clippy::write_with_newline \
+				   clippy::wrong_self_convention \
+				   renamed_and_removed_lints
 
 # Lints we disagree with and choose to keep in our code with no warning
 ALLOWED_LINTS =
@@ -128,15 +127,16 @@ LINTS_TO_FIX =
 
 # Lints we don't expect to have in our code at all and want to avoid adding
 # even at the cost of failing the build
-DENIED_LINTS = clippy::correctness
+DENIED_LINTS = clippy::assign_op_pattern \
+			   clippy::correctness
 
 define LINT
 lint-$1: ## executes the $1 component's linter checks
 	$(run) sh -c 'cd components/$1 && cargo clippy --all-targets --tests $(CARGO_FLAGS) -- \
-	                                               $(addprefix -A ,$(UNEXAMINED_LINTS)) \
-	                                               $(addprefix -A ,$(ALLOWED_LINTS)) \
-	                                               $(addprefix -W ,$(LINTS_TO_FIX)) \
-	                                               $(addprefix -D ,$(DENIED_LINTS))'
+												   $(addprefix -A ,$(UNEXAMINED_LINTS)) \
+												   $(addprefix -A ,$(ALLOWED_LINTS)) \
+												   $(addprefix -W ,$(LINTS_TO_FIX)) \
+												   $(addprefix -D ,$(DENIED_LINTS))'
 .PHONY: lint-$1
 endef
 $(foreach component,$(ALL),$(eval $(call LINT,$(component))))

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
 				   clippy::module_inception \
-				   clippy::needless_collect \
 				   clippy::needless_pass_by_value \
 				   clippy::needless_range_loop \
 				   clippy::needless_return \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::match_bool \
 			   clippy::match_ref_pats \
 			   clippy::needless_bool \
+			   clippy::needless_collect \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
-				   clippy::or_fun_call \
 				   clippy::println_empty_string \
 				   clippy::ptr_arg \
 				   clippy::question_mark \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::ok_expect \
 			   clippy::op_ref \
 			   clippy::option_map_unit_fn \
+			   clippy::or_fun_call \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
-				   clippy::let_and_return \
 				   clippy::let_unit_value \
 				   clippy::map_clone \
 				   clippy::match_bool \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::identity_conversion \
 			   clippy::if_let_some_result \
 			   clippy::len_zero \
+			   clippy::let_and_return \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::write_with_newline \
 				   clippy::wrong_self_convention \
 				   renamed_and_removed_lints
 
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::useless_format \
 			   clippy::useless_let_if_seq \
 			   clippy::useless_vec \
+			   clippy::write_with_newline \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::useless_let_if_seq \
 				   clippy::useless_vec \
 				   clippy::write_with_newline \
 				   clippy::wrong_self_convention \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::unused_unit \
 			   clippy::useless_asref \
 			   clippy::useless_format \
+			   clippy::useless_let_if_seq \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_without_default_derive \
 				   clippy::question_mark \
 				   clippy::redundant_field_names \
-				   clippy::redundant_pattern_matching \
 				   clippy::single_char_pattern \
 				   clippy::single_match \
 				   clippy::string_lit_as_bytes \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::println_empty_string \
 			   clippy::ptr_arg \
 			   clippy::redundant_closure \
+			   clippy::redundant_pattern_matching \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
-				   clippy::match_bool \
 				   clippy::match_ref_pats \
 				   clippy::module_inception \
 				   clippy::needless_bool \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::let_and_return \
 			   clippy::let_unit_value \
 			   clippy::map_clone \
+			   clippy::match_bool \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::len_without_is_empty \
 				   clippy::module_inception \
 				   clippy::needless_pass_by_value \
-				   clippy::needless_range_loop \
 				   clippy::needless_return \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::match_ref_pats \
 			   clippy::needless_bool \
 			   clippy::needless_collect \
+			   clippy::needless_range_loop \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
-				   clippy::match_ref_pats \
 				   clippy::module_inception \
 				   clippy::needless_bool \
 				   clippy::needless_collect \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::let_unit_value \
 			   clippy::map_clone \
 			   clippy::match_bool \
+			   clippy::match_ref_pats \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
-				   clippy::op_ref \
 				   clippy::option_map_unit_fn \
 				   clippy::or_fun_call \
 				   clippy::println_empty_string \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::needless_collect \
 			   clippy::needless_range_loop \
 			   clippy::ok_expect \
+			   clippy::op_ref \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-				   clippy::if_let_some_result \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
 				   clippy::len_zero \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::for_kv_map \
 			   clippy::get_unwrap \
 			   clippy::identity_conversion \
+			   clippy::if_let_some_result \
 
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
 				   clippy::question_mark \
-				   clippy::redundant_closure \
 				   clippy::redundant_field_names \
 				   clippy::redundant_pattern_matching \
 				   clippy::single_char_pattern \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::or_fun_call \
 			   clippy::println_empty_string \
 			   clippy::ptr_arg \
+			   clippy::redundant_closure \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-				   clippy::deref_addrof \
 				   clippy::expect_fun_call \
 				   clippy::for_kv_map \
 				   clippy::get_unwrap \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::collapsible_if \
 			   clippy::const_static_lifetime \
 			   clippy::correctness \
+			   clippy::deref_addrof \
 
 define LINT
 lint-$1: ## executes the $1 component's linter checks

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-				   clippy::for_kv_map \
 				   clippy::get_unwrap \
 				   clippy::identity_conversion \
 				   clippy::if_let_some_result \
@@ -129,6 +128,8 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::correctness \
 			   clippy::deref_addrof \
 			   clippy::expect_fun_call \
+			   clippy::for_kv_map \
+
 
 define LINT
 lint-$1: ## executes the $1 component's linter checks

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::collapsible_if \
-				   clippy::const_static_lifetime \
+UNEXAMINED_LINTS = clippy::const_static_lifetime \
 				   clippy::cyclomatic_complexity \
 				   clippy::deref_addrof \
 				   clippy::expect_fun_call \
@@ -128,6 +127,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::cast_lossless \
 			   clippy::clone_on_copy \
 			   clippy::cmp_owned \
+			   clippy::collapsible_if \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_without_default_derive \
 				   clippy::question_mark \
 				   clippy::redundant_field_names \
-				   clippy::single_match \
 				   clippy::string_lit_as_bytes \
 				   clippy::too_many_arguments \
 				   clippy::toplevel_ref_arg \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::redundant_closure \
 			   clippy::redundant_pattern_matching \
 			   clippy::single_char_pattern \
+			   clippy::single_match \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::new_ret_no_self \
 				   clippy::new_without_default \
 				   clippy::new_without_default_derive \
-				   clippy::ptr_arg \
 				   clippy::question_mark \
 				   clippy::redundant_closure \
 				   clippy::redundant_field_names \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::option_map_unit_fn \
 			   clippy::or_fun_call \
 			   clippy::println_empty_string \
+			   clippy::ptr_arg \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::large_enum_variant \
 				   clippy::len_without_is_empty \
-				   clippy::let_unit_value \
 				   clippy::map_clone \
 				   clippy::match_bool \
 				   clippy::match_ref_pats \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::if_let_some_result \
 			   clippy::len_zero \
 			   clippy::let_and_return \
+			   clippy::let_unit_value \
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::block_in_if_condition_stmt \
-				   clippy::bool_comparison \
+UNEXAMINED_LINTS = clippy::bool_comparison \
 				   clippy::cast_lossless \
 				   clippy::clone_on_copy \
 				   clippy::cmp_owned \
@@ -128,6 +127,7 @@ LINTS_TO_FIX =
 # even at the cost of failing the build
 DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::blacklisted_name \
+			   clippy::block_in_if_condition_stmt \
 			   clippy::correctness \
 
 define LINT

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
 				   clippy::redundant_field_names \
 				   clippy::too_many_arguments \
 				   clippy::trivially_copy_pass_by_ref \
-				   clippy::unused_label \
 				   clippy::unused_unit \
 				   clippy::useless_asref \
 				   clippy::useless_format \
@@ -129,6 +128,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
 			   clippy::unit_arg \
 			   clippy::unnecessary_operation \
 			   clippy::unreadable_literal \
+			   clippy::unused_label \
 
 
 

--- a/components/core/src/binlink.rs
+++ b/components/core/src/binlink.rs
@@ -16,14 +16,14 @@ use crate::env;
 
 /// Default Binlink Dir
 #[cfg(target_os = "windows")]
-pub const DEFAULT_BINLINK_DIR: &'static str = "/hab/bin";
+pub const DEFAULT_BINLINK_DIR: &str = "/hab/bin";
 #[cfg(target_os = "linux")]
-pub const DEFAULT_BINLINK_DIR: &'static str = "/bin";
+pub const DEFAULT_BINLINK_DIR: &str = "/bin";
 #[cfg(target_os = "macos")]
-pub const DEFAULT_BINLINK_DIR: &'static str = "/usr/local/bin";
+pub const DEFAULT_BINLINK_DIR: &str = "/usr/local/bin";
 
 /// Binlink Dir Environment variable
-pub const BINLINK_DIR_ENVVAR: &'static str = "HAB_BINLINK_DIR";
+pub const BINLINK_DIR_ENVVAR: &str = "HAB_BINLINK_DIR";
 
 pub fn default_binlink_dir() -> String {
     match env::var(BINLINK_DIR_ENVVAR) {

--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -38,5 +38,5 @@ fn legacy_default() -> String {
     env::var(LEGACY_CHANNEL_ENVVAR)
         .ok()
         .and_then(|c| Some(c.to_string()))
-        .unwrap_or(STABLE_CHANNEL.to_string())
+        .unwrap_or_else(|| STABLE_CHANNEL.to_string())
 }

--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -14,12 +14,12 @@
 
 use crate::env;
 
-pub const UNSTABLE_CHANNEL: &'static str = "unstable";
-pub const STABLE_CHANNEL: &'static str = "stable";
+pub const UNSTABLE_CHANNEL: &str = "unstable";
+pub const STABLE_CHANNEL: &str = "stable";
 
 /// Default Builder Channel environment variable
-pub const BLDR_CHANNEL_ENVVAR: &'static str = "HAB_BLDR_CHANNEL";
-const LEGACY_CHANNEL_ENVVAR: &'static str = "HAB_DEPOT_CHANNEL";
+pub const BLDR_CHANNEL_ENVVAR: &str = "HAB_BLDR_CHANNEL";
+const LEGACY_CHANNEL_ENVVAR: &str = "HAB_DEPOT_CHANNEL";
 
 /// Helper function for Builder dynamic channels
 pub fn bldr_channel_name(id: u64) -> String {

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -49,7 +49,7 @@ pub trait ConfigFile: DeserializeOwned + Sized {
     }
 
     fn from_raw(raw: &str) -> Result<Self, Self::Error> {
-        let value = toml::from_str(&raw).map_err(|e| Error::ConfigFileSyntax(e))?;
+        let value = toml::from_str(&raw).map_err(Error::ConfigFileSyntax)?;
         Ok(value)
     }
 }

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -527,6 +527,6 @@ mod test {
         let (key_name, _rev) = parse_name_with_rev(&hart_header.key_name).unwrap();
         assert_eq!("unicorn", key_name);
         assert_eq!(SIG_HASH_TYPE, hart_header.hash_type);
-        assert!(hart_header.signature_raw.len() > 0);
+        assert!(!hart_header.signature_raw.is_empty());
     }
 }

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -341,7 +341,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all("".as_bytes()).unwrap();
+        f.write_all(b"").unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -352,7 +352,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all("SOME-VERSION\nuhoh".as_bytes()).unwrap();
+        f.write_all(b"SOME-VERSION\nuhoh").unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -363,7 +363,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all("HART-1\n\nuhoh".as_bytes()).unwrap();
+        f.write_all(b"HART-1\n\nuhoh").unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -374,7 +374,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all("HART-1\nnope-nope\nuhoh".as_bytes()).unwrap();
+        f.write_all(b"HART-1\nnope-nope\nuhoh").unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -474,21 +474,21 @@ mod test {
         corrupted
             .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // version
-        corrupted.write_all("\n".as_bytes()).unwrap();
+        corrupted.write_all(b"\n").unwrap();
         corrupted
             .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // key
-        corrupted.write_all("\n".as_bytes()).unwrap();
+        corrupted.write_all(b"\n").unwrap();
         corrupted
             .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // hash type
-        corrupted.write_all("\n".as_bytes()).unwrap();
+        corrupted.write_all(b"\n").unwrap();
         corrupted
             .write_all(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // signature
-        corrupted.write_all("\n\n".as_bytes()).unwrap();
+        corrupted.write_all(b"\n\n").unwrap();
         corrupted
-            .write_all("payload-wont-match-signature".as_bytes())
+            .write_all(b"payload-wont-match-signature")
             .unwrap(); // archive
 
         verify(&dst_corrupted, cache.path()).unwrap();
@@ -502,13 +502,13 @@ mod test {
         let src = cache.path().join("src.in");
         let dst = cache.path().join("src.signed");
         let mut f = File::create(&src).unwrap();
-        f.write_all("hearty goodness".as_bytes()).unwrap();
+        f.write_all(b"hearty goodness").unwrap();
         sign(&src, &dst, &pair).unwrap();
 
         let mut buffer = String::new();
         let mut reader = get_archive_reader(&dst).unwrap();
         reader.read_to_string(&mut buffer).unwrap();
-        assert_eq!(buffer.as_bytes(), "hearty goodness".as_bytes());
+        assert_eq!(buffer.as_bytes(), b"hearty goodness");
     }
 
     #[test]
@@ -519,7 +519,7 @@ mod test {
         let src = cache.path().join("src.in");
         let dst = cache.path().join("src.signed");
         let mut f = File::create(&src).unwrap();
-        f.write_all("hearty goodness".as_bytes()).unwrap();
+        f.write_all(b"hearty goodness").unwrap();
         sign(&src, &dst, &pair).unwrap();
 
         let hart_header = get_artifact_header(&dst).unwrap();

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -38,7 +38,7 @@ where
     let signature = sign::sign(&hash.as_bytes(), pair.secret()?);
     let output_file = File::create(dst)?;
     let mut writer = BufWriter::new(&output_file);
-    let () = write!(
+    write!(
         writer,
         "{}\n{}\n{}\n{}\n\n",
         HART_FORMAT_VERSION,
@@ -181,7 +181,7 @@ where
         }
         SigKeyPair::get_pair_for(buffer.trim(), cache_key_path)?
     };
-    let _ = {
+    {
         let mut buffer = String::new();
         match reader.read_line(&mut buffer) {
             Ok(0) => {
@@ -211,7 +211,7 @@ where
             Err(e) => return Err(Error::from(e)),
         }
     };
-    let _ = {
+    {
         let mut buffer = String::new();
         if reader.read_line(&mut buffer)? == 0 {
             return Err(Error::CryptoError(

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -390,9 +390,9 @@ impl BoxKeyPair {
         sk: &BoxSecretKey,
     ) -> Result<Vec<u8>> {
         box_::open(ciphertext, nonce, pk, sk).map_err(|_| {
-            Error::CryptoError(format!(
-                "Secret key, public key, and nonce could not decrypt ciphertext"
-            ))
+            Error::CryptoError(
+                "Secret key, public key, and nonce could not decrypt ciphertext".to_string(),
+            )
         })
     }
 
@@ -402,9 +402,7 @@ impl BoxKeyPair {
         sk: &BoxSecretKey,
     ) -> Result<Vec<u8>> {
         sealedbox::open(ciphertext, &pk, &sk).map_err(|_| {
-            Error::CryptoError(format!(
-                "Secret key and public key could not decrypt ciphertext"
-            ))
+            Error::CryptoError("Secret key and public key could not decrypt ciphertext".to_string())
         })
     }
 
@@ -416,9 +414,9 @@ impl BoxKeyPair {
         match BoxPublicKey::from_slice(bytes) {
             Some(sk) => Ok(sk),
             None => {
-                return Err(Error::CryptoError(format!(
-                    "Can't convert key bytes to BoxPublicKey"
-                )))
+                return Err(Error::CryptoError(
+                    "Can't convert key bytes to BoxPublicKey".to_string(),
+                ))
             }
         }
     }
@@ -453,9 +451,9 @@ impl BoxKeyPair {
         match BoxSecretKey::from_slice(bytes) {
             Some(sk) => Ok(sk),
             None => {
-                return Err(Error::CryptoError(format!(
-                    "Can't convert key bytes to BoxSecretKey"
-                )))
+                return Err(Error::CryptoError(
+                    "Can't convert key bytes to BoxSecretKey".to_string(),
+                ))
             }
         }
     }

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -706,10 +706,10 @@ mod test {
         user.to_pair_files(cache.path()).unwrap();
 
         let ciphertext = user
-            .encrypt("I wish to buy more rockets".as_bytes(), Some(&service))
+            .encrypt(b"I wish to buy more rockets", Some(&service))
             .unwrap();
         let message = BoxKeyPair::decrypt_with_path(&ciphertext, cache.path()).unwrap();
-        assert_eq!(message, "I wish to buy more rockets".as_bytes());
+        assert_eq!(message, b"I wish to buy more rockets");
     }
 
     #[test]
@@ -720,11 +720,9 @@ mod test {
         let user = BoxKeyPair::generate_pair_for_user("wecoyote").unwrap();
         user.to_pair_files(cache.path()).unwrap();
 
-        let ciphertext = service
-            .encrypt("Out of rockets".as_bytes(), Some(&user))
-            .unwrap();
+        let ciphertext = service.encrypt(b"Out of rockets", Some(&user)).unwrap();
         let message = BoxKeyPair::decrypt_with_path(&ciphertext, cache.path()).unwrap();
-        assert_eq!(message, "Out of rockets".as_bytes());
+        assert_eq!(message, b"Out of rockets");
     }
 
     #[test]
@@ -733,9 +731,9 @@ mod test {
         let sender = BoxKeyPair::generate_pair_for_user("wecoyote").unwrap();
         sender.to_pair_files(cache.path()).unwrap();
 
-        let ciphertext = sender.encrypt("Buy more rockets".as_bytes(), None).unwrap();
+        let ciphertext = sender.encrypt(b"Buy more rockets", None).unwrap();
         let message = BoxKeyPair::decrypt_with_path(&ciphertext, cache.path()).unwrap();
-        assert_eq!(message, "Buy more rockets".as_bytes());
+        assert_eq!(message, b"Buy more rockets");
     }
 
     #[test]
@@ -752,7 +750,7 @@ mod test {
         // Now reload the sender's pair which will be missing the secret key
         let sender = BoxKeyPair::get_latest_pair_for("wecoyote", cache.path()).unwrap();
 
-        let ciphertext = sender.encrypt("Nothing to see here".as_bytes(), None);
+        let ciphertext = sender.encrypt(b"Nothing to see here", None);
         assert!(ciphertext.is_ok());
     }
 
@@ -812,16 +810,14 @@ mod test {
             let sender = BoxKeyPair::get_latest_pair_for("wecoyote", sender_cache.path()).unwrap();
             let receiver =
                 BoxKeyPair::get_latest_pair_for("tnt.default@acme", sender_cache.path()).unwrap();
-            sender
-                .encrypt("Falling hurts".as_bytes(), Some(&receiver))
-                .unwrap()
+            sender.encrypt(b"Falling hurts", Some(&receiver)).unwrap()
         };
 
         // Decrypt unpacks the ciphertext payload to read nonce , determines which secret key to
         // load for the receiver and which public key to load for the sender. We're using the
         // receiver's cache for the decrypt.
         let message = BoxKeyPair::decrypt_with_path(&ciphertext, receiver_cache.path()).unwrap();
-        assert_eq!(message, "Falling hurts".as_bytes());
+        assert_eq!(message, b"Falling hurts");
     }
 
     #[test]
@@ -842,7 +838,7 @@ mod test {
         let sender = BoxKeyPair::get_latest_pair_for("wecoyote", cache.path()).unwrap();
 
         sender
-            .encrypt("not going to happen".as_bytes(), Some(&receiver))
+            .encrypt(b"not going to happen", Some(&receiver))
             .unwrap();
     }
 
@@ -864,7 +860,7 @@ mod test {
         let receiver = BoxKeyPair::get_latest_pair_for("tnt.default@acme", cache.path()).unwrap();
 
         sender
-            .encrypt("not going to happen".as_bytes(), Some(&receiver))
+            .encrypt(b"not going to happen", Some(&receiver))
             .unwrap();
     }
 
@@ -883,9 +879,7 @@ mod test {
         )
         .unwrap();
 
-        let ciphertext = sender
-            .encrypt("problems ahead".as_bytes(), Some(&receiver))
-            .unwrap();
+        let ciphertext = sender.encrypt(b"problems ahead", Some(&receiver)).unwrap();
         BoxKeyPair::decrypt_with_path(&ciphertext, cache.path()).unwrap();
     }
 
@@ -904,9 +898,7 @@ mod test {
         )
         .unwrap();
 
-        let ciphertext = sender
-            .encrypt("problems ahead".as_bytes(), Some(&receiver))
-            .unwrap();
+        let ciphertext = sender.encrypt(b"problems ahead", Some(&receiver)).unwrap();
         BoxKeyPair::decrypt_with_path(&ciphertext, cache.path()).unwrap();
     }
 
@@ -914,14 +906,14 @@ mod test {
     #[should_panic]
     fn decrypt_empty_sender_key() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        BoxKeyPair::decrypt_with_path("BOX-1\n\nuhoh".as_bytes(), cache.path()).unwrap();
+        BoxKeyPair::decrypt_with_path(b"BOX-1\n\nuhoh", cache.path()).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn decrypt_invalid_sender_key() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        BoxKeyPair::decrypt_with_path("BOX-1\nnope-nope\nuhoh".as_bytes(), cache.path()).unwrap();
+        BoxKeyPair::decrypt_with_path(b"BOX-1\nnope-nope\nuhoh", cache.path()).unwrap();
     }
 
     #[test]
@@ -989,9 +981,7 @@ mod test {
         let receiver = BoxKeyPair::generate_pair_for_service("acme", "tnt.default").unwrap();
         receiver.to_pair_files(cache.path()).unwrap();
 
-        let payload = sender
-            .encrypt("problems ahead".as_bytes(), Some(&receiver))
-            .unwrap();
+        let payload = sender.encrypt(b"problems ahead", Some(&receiver)).unwrap();
         let mut botched = String::new();
         let mut lines = str::from_utf8(payload.as_slice()).unwrap().lines();
         botched.push_str(lines.next().unwrap()); // version
@@ -1016,9 +1006,7 @@ mod test {
         let receiver = BoxKeyPair::generate_pair_for_service("acme", "tnt.default").unwrap();
         receiver.to_pair_files(cache.path()).unwrap();
 
-        let payload = sender
-            .encrypt("problems ahead".as_bytes(), Some(&receiver))
-            .unwrap();
+        let payload = sender.encrypt(b"problems ahead", Some(&receiver)).unwrap();
         let mut botched = String::new();
         let mut lines = str::from_utf8(payload.as_slice()).unwrap().lines();
         botched.push_str(lines.next().unwrap()); // version

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -304,7 +304,9 @@ where
             Err(e) => {
                 // filename is still an OsString, so print it as debug output
                 debug!("Invalid filename {:?}", e);
-                return Err(Error::CryptoError(format!("Invalid filename in key path")));
+                return Err(Error::CryptoError(
+                    "Invalid filename in key path".to_string(),
+                ));
             }
         };
         debug!("checking file: {}", &filename);
@@ -494,7 +496,7 @@ fn read_key_bytes_from_str(key: &str) -> Result<Vec<u8>> {
                 .map_err(|e| Error::CryptoError(format!("Can't read raw key {}", e)))?;
             Ok(v)
         }
-        None => Err(Error::CryptoError(format!("Malformed key contents"))),
+        None => Err(Error::CryptoError("Malformed key contents".to_string())),
     }
 }
 

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -222,22 +222,11 @@ fn check_filename(
 
         let do_insert = match pair_type {
             Some(&PairType::Secret) => {
-                if suffix == SECRET_SIG_KEY_SUFFIX
+                suffix == SECRET_SIG_KEY_SUFFIX
                     || suffix == SECRET_BOX_KEY_SUFFIX
                     || suffix == SECRET_SYM_KEY_SUFFIX
-                {
-                    true
-                } else {
-                    false
-                }
             }
-            Some(&PairType::Public) => {
-                if suffix == PUBLIC_KEY_SUFFIX {
-                    true
-                } else {
-                    false
-                }
-            }
+            Some(&PairType::Public) => suffix == PUBLIC_KEY_SUFFIX,
             None => true,
         };
 

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -669,7 +669,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let keyfile = cache.path().join("missing-newlines");
         let mut f = File::create(&keyfile).unwrap();
-        f.write_all("SOMETHING\nELSE\n".as_bytes()).unwrap();
+        f.write_all(b"SOMETHING\nELSE\n").unwrap();
 
         super::read_key_bytes(keyfile.as_path()).unwrap();
     }
@@ -680,7 +680,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let keyfile = cache.path().join("missing-newlines");
         let mut f = File::create(&keyfile).unwrap();
-        f.write_all("header\nsomething\n\nI am not base64 content".as_bytes())
+        f.write_all(b"header\nsomething\n\nI am not base64 content")
             .unwrap();
 
         super::read_key_bytes(keyfile.as_path()).unwrap();

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -431,7 +431,7 @@ mod test {
         let pairs = SigKeyPair::get_pairs_for("unicorn", cache.path(), None).unwrap();
         assert_eq!(pairs.len(), 1);
 
-        let _ = match wait_until_ok(|| {
+        match wait_until_ok(|| {
             let p = SigKeyPair::generate_pair_for_origin("unicorn")?;
             p.to_pair_files(cache.path())?;
             Ok(())

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -341,7 +341,6 @@ impl SymKey {
                         val
                     )));
                 }
-                ()
             }
             None => {
                 let msg = format!(

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -620,7 +620,7 @@ mod test {
         let pair = SymKey::generate_pair_for_ring("beyonce").unwrap();
         pair.to_pair_files(cache.path()).unwrap();
 
-        let (nonce, ciphertext) = pair.encrypt("Ringonit".as_bytes()).unwrap();
+        let (nonce, ciphertext) = pair.encrypt(b"Ringonit").unwrap();
         let message = pair.decrypt(&nonce, &ciphertext).unwrap();
         assert_eq!(message, "Ringonit".to_string().into_bytes());
     }
@@ -630,7 +630,7 @@ mod test {
     fn encrypt_missing_secret_key() {
         let pair = SymKey::new("grohl".to_string(), "201604051449".to_string(), None, None);
 
-        pair.encrypt("Not going to go well".as_bytes()).unwrap();
+        pair.encrypt(b"Not going to go well").unwrap();
     }
 
     #[test]
@@ -639,7 +639,7 @@ mod test {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
         let pair = SymKey::generate_pair_for_ring("beyonce").unwrap();
         pair.to_pair_files(cache.path()).unwrap();
-        let (nonce, ciphertext) = pair.encrypt("Ringonit".as_bytes()).unwrap();
+        let (nonce, ciphertext) = pair.encrypt(b"Ringonit").unwrap();
 
         let missing = SymKey::new("grohl".to_string(), "201604051449".to_string(), None, None);
         missing.decrypt(&nonce, &ciphertext).unwrap();
@@ -652,8 +652,8 @@ mod test {
         let pair = SymKey::generate_pair_for_ring("beyonce").unwrap();
         pair.to_pair_files(cache.path()).unwrap();
 
-        let (_, ciphertext) = pair.encrypt("Ringonit".as_bytes()).unwrap();
-        pair.decrypt("crazyinlove".as_bytes(), &ciphertext).unwrap();
+        let (_, ciphertext) = pair.encrypt(b"Ringonit").unwrap();
+        pair.decrypt(b"crazyinlove", &ciphertext).unwrap();
     }
 
     #[test]
@@ -663,8 +663,8 @@ mod test {
         let pair = SymKey::generate_pair_for_ring("beyonce").unwrap();
         pair.to_pair_files(cache.path()).unwrap();
 
-        let (nonce, _) = pair.encrypt("Ringonit".as_bytes()).unwrap();
-        pair.decrypt(&nonce, "singleladies".as_bytes()).unwrap();
+        let (nonce, _) = pair.encrypt(b"Ringonit").unwrap();
+        pair.decrypt(&nonce, b"singleladies").unwrap();
     }
 
     #[test]

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -71,28 +71,24 @@ impl SymKey {
         cache_key_path: &P,
     ) -> Result<Self> {
         let (name, rev) = parse_name_with_rev(&name_with_rev)?;
-        let pk = match Self::get_public_key(name_with_rev, cache_key_path.as_ref()) {
-            Ok(k) => Some(k),
-            Err(e) => {
-                // Not an error, just continue
+        let pk = Self::get_public_key(name_with_rev, cache_key_path.as_ref())
+            .map_err(|e| {
                 debug!(
                     "Can't find public key for name_with_rev {}: {}",
                     name_with_rev, e
                 );
-                None
-            }
-        };
-        let sk = match Self::get_secret_key(name_with_rev, cache_key_path.as_ref()) {
-            Ok(k) => Some(k),
-            Err(e) => {
-                // Not an error, just continue
+                e
+            })
+            .ok();
+        let sk = Self::get_secret_key(name_with_rev, cache_key_path.as_ref())
+            .map_err(|e| {
                 debug!(
                     "Can't find secret key for name_with_rev {}: {}",
                     name_with_rev, e
                 );
-                None
-            }
-        };
+                e
+            })
+            .ok();
         if pk == None && sk == None {
             let msg = format!(
                 "No public or secret keys found for name_with_rev {}",

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -337,7 +337,7 @@ impl SymKey {
         cache_key_path: &P,
     ) -> Result<(Self, PairType)> {
         let mut lines = content.lines();
-        let _ = match lines.next() {
+        match lines.next() {
             Some(val) => {
                 if val != SECRET_SYM_KEY_VERSION {
                     return Err(Error::CryptoError(format!(
@@ -499,7 +499,7 @@ mod test {
         let pairs = SymKey::get_pairs_for("beyonce", cache.path()).unwrap();
         assert_eq!(pairs.len(), 1);
 
-        let _ = match wait_until_ok(|| {
+        match wait_until_ok(|| {
             let rpair = SymKey::generate_pair_for_ring("beyonce")?;
             rpair.to_pair_files(cache.path())?;
             Ok(())

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -256,11 +256,11 @@ pub static ANONYMOUS_BOX_FORMAT_VERSION: &'static str = "ANONYMOUS-BOX-1";
 #[cfg(not(windows))]
 static KEY_PERMISSIONS: u32 = 0o400;
 
-pub const PUBLIC_SIG_KEY_VERSION: &'static str = "SIG-PUB-1";
-pub const SECRET_SIG_KEY_VERSION: &'static str = "SIG-SEC-1";
-pub const PUBLIC_BOX_KEY_VERSION: &'static str = "BOX-PUB-1";
-pub const SECRET_BOX_KEY_VERSION: &'static str = "BOX-SEC-1";
-pub const SECRET_SYM_KEY_VERSION: &'static str = "SYM-SEC-1";
+pub const PUBLIC_SIG_KEY_VERSION: &str = "SIG-PUB-1";
+pub const SECRET_SIG_KEY_VERSION: &str = "SIG-SEC-1";
+pub const PUBLIC_BOX_KEY_VERSION: &str = "BOX-PUB-1";
+pub const SECRET_BOX_KEY_VERSION: &str = "BOX-SEC-1";
+pub const SECRET_SYM_KEY_VERSION: &str = "SYM-SEC-1";
 
 pub mod artifact;
 #[cfg(windows)]

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -255,8 +255,8 @@ impl fmt::Display for Error {
                 format!("Failure calling CreateProcessAsUserW: {:?}", e)
             }
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
-            Error::CryptProtectDataFailed(ref e) => format!("{}", e),
-            Error::CryptUnprotectDataFailed(ref e) => format!("{}", e),
+            Error::CryptProtectDataFailed(ref e) => e.to_string(),
+            Error::CryptUnprotectDataFailed(ref e) => e.to_string(),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
             Error::FullyQualifiedPackageIdentRequired(ref ident) => format!(
                 "Fully-qualified package identifier was expected, but found: {:?}",
@@ -294,21 +294,24 @@ impl fmt::Display for Error {
             }
             Error::IO(ref err) => format!("{}", err),
             Error::JoinPathsError(ref err) => format!("{}", err),
-            Error::LogonTypeNotGranted => format!(
+            Error::LogonTypeNotGranted => {
                 "hab_svc_user user must possess the 'SE_SERVICE_LOGON_NAME' \
                  account right to be spawned as a service by the Supervisor"
-            ),
+                    .to_string()
+            }
             Error::LogonUserFailed(ref e) => format!("Failure calling LogonUserW: {:?}", e),
             Error::MetaFileBadBind => {
-                format!("Bad value parsed from BIND, BIND_OPTIONAL, or BIND_MAP")
+                "Bad value parsed from BIND, BIND_OPTIONAL, or BIND_MAP".to_string()
             }
             Error::MetaFileMalformed(ref e) => {
                 format!("MetaFile: {:?}, didn't contain a valid UTF-8 string", e)
             }
             Error::MetaFileNotFound(ref e) => format!("Couldn't read MetaFile: {}, not found", e),
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
-            Error::NoOutboundAddr => format!("Failed to discover this hosts outbound IP address"),
-            Error::OpenDesktopFailed(ref e) => format!("{}", e),
+            Error::NoOutboundAddr => {
+                "Failed to discover this hosts outbound IP address".to_string()
+            }
+            Error::OpenDesktopFailed(ref e) => e.to_string(),
             Error::PackageNotFound(ref pkg) => {
                 if pkg.fully_qualified() {
                     format!("Cannot find package: {}", pkg)
@@ -318,25 +321,26 @@ impl fmt::Display for Error {
             }
             Error::PackageUnpackFailed(ref e) => format!("Package could not be unpacked. {}", e),
             Error::ParseIntError(ref e) => format!("{}", e),
-            Error::PlanMalformed => format!("Failed to read or parse contents of Plan file"),
-            Error::PermissionFailed(ref e) => format!("{}", e),
-            Error::PrivilegeNotHeld => format!(
+            Error::PlanMalformed => "Failed to read or parse contents of Plan file".to_string(),
+            Error::PermissionFailed(ref e) => e.to_string(),
+            Error::PrivilegeNotHeld => {
                 "Current user must possess the 'SE_INCREASE_QUOTA_NAME' and \
                  'SE_ASSIGNPRIMARYTOKEN_NAME' privilege to spawn a new process as a different \
                  user"
-            ),
+                    .to_string()
+            }
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
-            Error::TargetMatchError(ref e) => format!("{}", e),
-            Error::UnameFailed(ref e) => format!("{}", e),
-            Error::WaitpidFailed(ref e) => format!("{}", e),
+            Error::TargetMatchError(ref e) => e.to_string(),
+            Error::UnameFailed(ref e) => e.to_string(),
+            Error::WaitpidFailed(ref e) => e.to_string(),
             Error::SignalFailed(ref r, ref e) => {
                 format!("Failed to send a signal to the child process: {}, {}", r, e)
             }
-            Error::GetExitCodeProcessFailed(ref e) => format!("{}", e),
-            Error::CreateToolhelp32SnapshotFailed(ref e) => format!("{}", e),
-            Error::WaitForSingleObjectFailed(ref e) => format!("{}", e),
-            Error::TerminateProcessFailed(ref e) => format!("{}", e),
+            Error::GetExitCodeProcessFailed(ref e) => e.to_string(),
+            Error::CreateToolhelp32SnapshotFailed(ref e) => e.to_string(),
+            Error::WaitForSingleObjectFailed(ref e) => e.to_string(),
+            Error::TerminateProcessFailed(ref e) => e.to_string(),
             Error::Utf8Error(ref e) => format!("{}", e),
             Error::WrongActivePackageTarget(ref active, ref wrong) => format!(
                 "Package target '{}' is not supported as this system has a different \

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -518,10 +518,9 @@ where
     U: AsRef<Path>,
 {
     for path in pkg_install.paths()? {
-        let stripped = path.strip_prefix("/").expect(&format!(
-            "Package path missing / prefix {}",
-            path.to_string_lossy()
-        ));
+        let stripped = path
+            .strip_prefix("/")
+            .unwrap_or_else(|_| panic!("Package path missing / prefix {}", path.to_string_lossy()));
         let candidate = fs_root_path.as_ref().join(stripped).join(command.as_ref());
         if candidate.is_file() {
             return Ok(Some(path.join(command.as_ref())));

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -25,34 +25,34 @@ use crate::os::users::{self, assert_pkg_user_and_group};
 use crate::package::{Identifiable, PackageIdent, PackageInstall};
 
 /// The default root path of the Habitat filesystem
-pub const ROOT_PATH: &'static str = "hab";
+pub const ROOT_PATH: &str = "hab";
 /// The default path for any analytics related files
-pub const CACHE_ANALYTICS_PATH: &'static str = "hab/cache/analytics";
+pub const CACHE_ANALYTICS_PATH: &str = "hab/cache/analytics";
 /// The default download root path for package artifacts, used on package installation
-pub const CACHE_ARTIFACT_PATH: &'static str = "hab/cache/artifacts";
+pub const CACHE_ARTIFACT_PATH: &str = "hab/cache/artifacts";
 /// The default path where cryptographic keys are stored
-pub const CACHE_KEY_PATH: &'static str = "hab/cache/keys";
+pub const CACHE_KEY_PATH: &str = "hab/cache/keys";
 /// The default path where source artifacts are downloaded, extracted, & compiled
-pub const CACHE_SRC_PATH: &'static str = "hab/cache/src";
+pub const CACHE_SRC_PATH: &str = "hab/cache/src";
 /// The default path where SSL-related artifacts are placed
-pub const CACHE_SSL_PATH: &'static str = "hab/cache/ssl";
+pub const CACHE_SSL_PATH: &str = "hab/cache/ssl";
 /// The root path for the launcher runtime
-pub const LAUNCHER_ROOT_PATH: &'static str = "hab/launcher";
+pub const LAUNCHER_ROOT_PATH: &str = "hab/launcher";
 /// The root path containing all locally installed packages
 /// Because this value is used in template rendering, we
 /// use native directory separator
 #[cfg(not(target_os = "windows"))]
-pub const PKG_PATH: &'static str = "hab/pkgs";
+pub const PKG_PATH: &str = "hab/pkgs";
 #[cfg(target_os = "windows")]
-pub const PKG_PATH: &'static str = "hab\\pkgs";
+pub const PKG_PATH: &str = "hab\\pkgs";
 /// The environment variable pointing to the filesystem root. This exists for internal
 /// Habitat team usage and is not intended to be used by Habitat consumers.
 /// Using this variable could lead to broken Supervisor services and it should
 /// be used with extreme caution.
-pub const FS_ROOT_ENVVAR: &'static str = "FS_ROOT";
-pub const SYSTEMDRIVE_ENVVAR: &'static str = "SYSTEMDRIVE";
+pub const FS_ROOT_ENVVAR: &str = "FS_ROOT";
+pub const SYSTEMDRIVE_ENVVAR: &str = "SYSTEMDRIVE";
 /// The file where user-defined configuration for each service is found.
-pub const USER_CONFIG_FILE: &'static str = "user.toml";
+pub const USER_CONFIG_FILE: &str = "user.toml";
 /// Permissions that service-owned service directories should
 /// have. The user and group will be `SVC_USER` / `SVC_GROUP`.
 #[cfg(not(windows))]

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -64,7 +64,7 @@ pub const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN";
 
 lazy_static::lazy_static! {
     pub static ref PROGRAM_NAME: String = {
-        let arg0 = std::env::args().next().map(|p| PathBuf::from(p));
+        let arg0 = std::env::args().next().map(PathBuf::from);
         arg0.as_ref()
             .and_then(|p| p.file_stem())
             .and_then(|p| p.to_str())

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -60,7 +60,7 @@ use std::path::PathBuf;
 pub use crate::os::filesystem;
 pub use crate::os::users;
 
-pub const AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
+pub const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN";
 
 lazy_static::lazy_static! {
     pub static ref PROGRAM_NAME: String = {

--- a/components/core/src/os/ffi/windows.rs
+++ b/components/core/src/os/ffi/windows.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::ffi::OsStr;
-const INVALID_UTF8: &'static str = "unexpected invalid UTF-8 code point";
+const INVALID_UTF8: &str = "unexpected invalid UTF-8 code point";
 
 pub trait OsStrExt3 {
     fn from_bytes(b: &[u8]) -> &Self;

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -122,15 +122,10 @@ pub fn assert_pkg_user_and_group(user: &str, group: &str) -> Result<()> {
     let current_user = current_user.unwrap();
     let current_group = current_group.unwrap();
 
-    if current_user == root_level_account() {
+    if current_user == root_level_account() || (current_user == user && current_group == group) {
         Ok(())
     } else {
-        if current_user == user && current_group == group {
-            // ok, sup is running as svc_user/svc_group already
-            Ok(())
-        } else {
-            let msg = format!("Package must run as {}:{} or root", user, &group);
-            return Err(Error::PermissionFailed(msg));
-        }
+        let msg = format!("Package must run as {}:{} or root", user, &group);
+        return Err(Error::PermissionFailed(msg));
     }
 }

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -91,13 +91,13 @@ pub fn root_level_account() -> String {
 ///     b) we are the specified user:group
 ///     c) fail otherwise
 pub fn assert_pkg_user_and_group(user: &str, group: &str) -> Result<()> {
-    if let None = get_uid_by_name(user) {
+    if get_uid_by_name(user).is_none() {
         return Err(Error::PermissionFailed(format!(
             "Package requires user {} to exist, but it doesn't",
             user
         )));
     }
-    if let None = get_gid_by_name(&group) {
+    if get_gid_by_name(&group).is_none() {
         return Err(Error::PermissionFailed(format!(
             "Package requires group {} to exist, but it doesn't",
             group
@@ -107,13 +107,13 @@ pub fn assert_pkg_user_and_group(user: &str, group: &str) -> Result<()> {
     let current_user = get_current_username();
     let current_group = get_current_groupname();
 
-    if let None = current_user {
+    if current_user.is_none() {
         return Err(Error::PermissionFailed(
             "Can't determine current user".to_string(),
         ));
     }
 
-    if let None = current_group {
+    if current_group.is_none() {
         return Err(Error::PermissionFailed(
             "Can't determine current group".to_string(),
         ));

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -64,13 +64,7 @@ pub fn set_verbose(booly: bool) {
 
 /// True if color is enabled
 pub fn is_color() -> bool {
-    unsafe {
-        if NO_COLOR.load(Ordering::Relaxed) {
-            false
-        } else {
-            true
-        }
-    }
+    unsafe { !NO_COLOR.load(Ordering::Relaxed) }
 }
 
 /// Set to true if you want color to turn off.

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -202,18 +202,16 @@ impl<'a> fmt::Display for StructuredOutput<'a> {
                         self.preamble, self.logkey, self.file, self.line, self.column, self.content
                     )
                 }
+            } else if color {
+                write!(
+                    f,
+                    "{}({}): {}",
+                    preamble_color.paint(self.preamble),
+                    White.bold().paint(self.logkey),
+                    self.content
+                )
             } else {
-                if color {
-                    write!(
-                        f,
-                        "{}({}): {}",
-                        preamble_color.paint(self.preamble),
-                        White.bold().paint(self.logkey),
-                        self.content
-                    )
-                } else {
-                    write!(f, "{}({}): {}", self.preamble, self.logkey, self.content)
-                }
+                write!(f, "{}({}): {}", self.preamble, self.logkey, self.content)
             }
         }
     }

--- a/components/core/src/output.rs
+++ b/components/core/src/output.rs
@@ -135,7 +135,7 @@ impl<'a> Serialize for StructuredOutput<'a> {
     where
         S: Serializer,
     {
-        let verbose = self.verbose.unwrap_or(is_verbose());
+        let verbose = self.verbose.unwrap_or_else(is_verbose);
 
         // Focused on JSON serialization right now, so the length hint
         // isn't needed; it might be later if we target other formats.
@@ -159,7 +159,7 @@ impl<'a> Serialize for StructuredOutput<'a> {
 // function. Viola!
 impl<'a> fmt::Display for StructuredOutput<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.json.unwrap_or(is_json()) {
+        if self.json.unwrap_or_else(is_json) {
             // Our JSON serialization handles verbosity itself, and
             // color is ignored anyway, so there's no reason to check
             // those settings here.
@@ -168,8 +168,8 @@ impl<'a> fmt::Display for StructuredOutput<'a> {
             let as_json = serde_json::to_string(&self).unwrap();
             write!(f, "{}", as_json)
         } else {
-            let verbose = self.verbose.unwrap_or(is_verbose());
-            let color = self.color.unwrap_or(is_color());
+            let verbose = self.verbose.unwrap_or_else(is_verbose);
+            let color = self.color.unwrap_or_else(is_color);
 
             let preamble_color = if self.preamble == PROGRAM_NAME.as_str() {
                 Cyan

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -338,7 +338,7 @@ impl PackageArchive {
     ///
     /// * If the package cannot be unpacked
     pub fn unpack(&self, fs_root_path: Option<&Path>) -> Result<()> {
-        let root = fs_root_path.unwrap_or(Path::new("/"));
+        let root = fs_root_path.unwrap_or_else(|| Path::new("/"));
         let tar_reader = artifact::get_archive_reader(&self.path)?;
         let mut builder = reader::Builder::new();
         builder.support_format(ReadFormat::Gnutar)?;

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -233,7 +233,7 @@ impl PackageArchive {
         match self.read_metadata(MetaFile::Exposes) {
             Ok(Some(data)) => {
                 let ports: Vec<u16> = data
-                    .split(" ")
+                    .split(' ')
                     .filter_map(|port| port.parse::<u16>().ok())
                     .collect();
                 Ok(ports)

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -704,9 +704,8 @@ mod tests {
 
     #[test]
     fn version_sort_error() {
-        match version_sort("1.0.0-alpha1", "undefined") {
-            Ok(compare) => panic!("unexpected {:?}", compare),
-            Err(_) => (),
+        if let Ok(compare) = version_sort("1.0.0-alpha1", "undefined") {
+            panic!("unexpected {:?}", compare);
         }
     }
 

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -237,7 +237,7 @@ impl FromStr for PackageIdent {
     type Err = Error;
 
     fn from_str(value: &str) -> result::Result<Self, Self::Err> {
-        let items: Vec<&str> = value.split("/").collect();
+        let items: Vec<&str> = value.split('/').collect();
         let (origin, name, ver, rel) = match items.len() {
             2 => (items[0], items[1], None, None),
             3 => (items[0], items[1], Some(items[2]), None),

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -95,7 +95,7 @@ impl PackageIdent {
         self.archive_name_impl(PackageTarget::active_target())
     }
 
-    pub fn archive_name_with_target(&self, ref target: &PackageTarget) -> Result<String> {
+    pub fn archive_name_with_target(&self, target: &PackageTarget) -> Result<String> {
         self.archive_name_impl(target)
     }
 
@@ -162,7 +162,7 @@ impl PackageIdent {
         }
     }
 
-    fn archive_name_impl(&self, ref target: &PackageTarget) -> Result<String> {
+    fn archive_name_impl(&self, target: &PackageTarget) -> Result<String> {
         if self.fully_qualified() {
             Ok(format!(
                 "{}-{}-{}-{}-{}.hart",

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -301,13 +301,13 @@ impl PackageInstall {
             Ok(body) => {
                 let mut bind_map = HashMap::new();
                 for line in body.lines() {
-                    let mut parts = line.split("=");
+                    let mut parts = line.split('=');
                     let package = match parts.next() {
                         Some(ident) => ident.parse()?,
                         None => return Err(Error::MetaFileBadBind),
                     };
                     let binds: Result<Vec<BindMapping>> = match parts.next() {
-                        Some(binds) => binds.split(" ").map(|b| b.parse()).collect(),
+                        Some(binds) => binds.split(' ').map(|b| b.parse()).collect(),
                         None => Err(Error::MetaFileBadBind),
                     };
                     bind_map.insert(package, binds?);
@@ -542,7 +542,7 @@ impl PackageInstall {
     fn parse_runtime_environment_metafile(body: &str) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
         for line in body.lines() {
-            let parts: Vec<&str> = line.splitn(2, "=").collect();
+            let parts: Vec<&str> = line.splitn(2, '=').collect();
             if parts.len() != 2 {
                 return Err(Error::MetaFileMalformed(MetaFile::RuntimeEnvironment));
             }

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -123,7 +123,7 @@ impl PackageInstall {
             if let Some(id) = latest {
                 Ok(PackageInstall {
                     installed_path: fs::pkg_install_path(&id, Some(&fs_root_path)),
-                    fs_root_path: PathBuf::from(fs_root_path),
+                    fs_root_path: fs_root_path,
                     package_root_path: package_root_path,
                     ident: id.clone(),
                 })

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -203,13 +203,8 @@ impl PackageInstall {
     pub fn is_runnable(&self) -> bool {
         // Currently, a runnable package can be determined by checking if a `run` hook exists in
         // package's hooks directory or directly in the package prefix.
-        if self.installed_path.join("hooks").join("run").is_file()
+        self.installed_path.join("hooks").join("run").is_file()
             || self.installed_path.join("run").is_file()
-        {
-            true
-        } else {
-            false
-        }
     }
 
     /// Determine what kind of package this is.

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -244,7 +244,7 @@ impl PackageInstall {
 
         let joined = env::join_paths(paths)?
             .into_string()
-            .map_err(|s| Error::InvalidPathString(s))?;
+            .map_err(Error::InvalidPathString)?;
         // Only insert a PATH entry if the resulting path string is non-empty
         if !joined.is_empty() {
             env.insert(PATH_KEY.to_string(), joined);

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -35,8 +35,8 @@ use super::PackageTarget;
 #[cfg(test)]
 use std;
 
-pub const DEFAULT_CFG_FILE: &'static str = "default.toml";
-const PATH_KEY: &'static str = "PATH";
+pub const DEFAULT_CFG_FILE: &str = "default.toml";
+const PATH_KEY: &str = "PATH";
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PackageInstall {

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -625,7 +625,7 @@ impl PackageInstall {
 
         match self.read_metafile(file) {
             Ok(body) => {
-                if body.len() > 0 {
+                if !body.is_empty() {
                     for id in body.lines() {
                         let package = PackageIdent::from_str(id)?;
                         if !package.fully_qualified() && must_be_fully_qualified {

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -71,7 +71,7 @@ pub fn all_packages(path: &Path) -> Result<Vec<PackageIdent>> {
 ///
 ///    /base/ORIGIN/NAME/VERSION/RELEASE/
 ///
-pub fn package_list_for_origin(base_pkg_path: &Path, origin: &String) -> Result<Vec<PackageIdent>> {
+pub fn package_list_for_origin(base_pkg_path: &Path, origin: &str) -> Result<Vec<PackageIdent>> {
     let mut package_list: Vec<PackageIdent> = vec![];
     let mut package_path = PathBuf::from(base_pkg_path);
     package_path.push(&origin);
@@ -164,7 +164,7 @@ fn walk_origins(path: &Path, packages: &mut Vec<PackageIdent>) -> Result<()> {
 /// Helper function for walk_origins. Walks the direcotry at the given
 /// Path for name directories and recurses into them to find version
 /// and release directories.
-fn walk_names(origin: &String, dir: &Path, packages: &mut Vec<PackageIdent>) -> Result<()> {
+fn walk_names(origin: &str, dir: &Path, packages: &mut Vec<PackageIdent>) -> Result<()> {
     for entry in fs::read_dir(dir)? {
         let name_dir = entry?;
         let name_path = name_dir.path();
@@ -179,8 +179,8 @@ fn walk_names(origin: &String, dir: &Path, packages: &mut Vec<PackageIdent>) -> 
 /// Helper function for walk_names. Walks the directory at the given
 /// Path and recurses into them to find release directories.
 fn walk_versions(
-    origin: &String,
-    name: &String,
+    origin: &str,
+    name: &str,
     dir: &Path,
     packages: &mut Vec<PackageIdent>,
 ) -> Result<()> {
@@ -201,9 +201,9 @@ fn walk_versions(
 /// the given packages vector, assuming the given origin, name, and
 /// version.
 fn walk_releases(
-    origin: &String,
-    name: &String,
-    version: &String,
+    origin: &str,
+    name: &str,
+    version: &str,
     dir: &Path,
     packages: &mut Vec<PackageIdent>,
 ) -> Result<()> {
@@ -231,9 +231,9 @@ fn walk_releases(
 ///    - An error occurs reading the package target
 ///    - The package target doesn't match the given active target
 fn package_ident_from_dir(
-    origin: &String,
-    name: &String,
-    version: &String,
+    origin: &str,
+    name: &str,
+    version: &str,
     active_target: &PackageTarget,
     dir: &Path,
 ) -> Option<PackageIdent> {
@@ -286,9 +286,9 @@ fn package_ident_from_dir(
     // otherwise skip the candidate
     if active_target == &install_target {
         return Some(PackageIdent::new(
-            origin.clone(),
-            name.clone(),
-            Some(version.clone()),
+            origin.to_string(),
+            name.to_string(),
+            Some(version.to_string()),
             Some(release.to_owned()),
         ));
     } else {

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -25,7 +25,7 @@ use crate::error::{Error, Result};
 use tempfile::Builder;
 use tempfile::TempDir;
 
-pub const INSTALL_TMP_PREFIX: &'static str = ".hab-pkg-install";
+pub const INSTALL_TMP_PREFIX: &str = ".hab-pkg-install";
 
 /// Return a directory which can be used as a temp dir during package install/
 /// uninstall

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -33,17 +33,21 @@ pub const INSTALL_TMP_PREFIX: &str = ".hab-pkg-install";
 /// It returns a path which is in the same parent directory as `path`
 /// but with TempDir style randomization
 pub fn temp_package_directory(path: &Path) -> Result<TempDir> {
-    let base = path.parent().ok_or(Error::PackageUnpackFailed(
-        "Could not determine parent directory for temporary package directory".to_owned(),
-    ))?;
+    let base = path.parent().ok_or_else(|| {
+        Error::PackageUnpackFailed(
+            "Could not determine parent directory for temporary package directory".to_owned(),
+        )
+    })?;
     fs::create_dir_all(base)?;
     let temp_install_prefix = path
         .file_name()
         .and_then(|f| f.to_str())
         .and_then(|dirname| Some(format!("{}-{}", INSTALL_TMP_PREFIX, dirname)))
-        .ok_or(Error::PackageUnpackFailed(
-            "Could not generate prefix for temporary package directory".to_owned(),
-        ))?;
+        .ok_or_else(|| {
+            Error::PackageUnpackFailed(
+                "Could not generate prefix for temporary package directory".to_owned(),
+            )
+        })?;
     Ok(Builder::new()
         .prefix(&temp_install_prefix)
         .tempdir_in(base)?)

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -275,7 +275,7 @@ impl FromStr for PackageType {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self> {
-        match value.as_ref() {
+        match value {
             "standalone" => Ok(PackageType::Standalone),
             "composite" => Ok(PackageType::Composite),
             _ => Err(Error::InvalidPackageType(value.to_string())),

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -57,10 +57,10 @@ pub mod test_support {
 
         let mut pkg_ident = PackageIdent::from_str(ident).unwrap();
         if !pkg_ident.fully_qualified() {
-            if let None = pkg_ident.version {
+            if pkg_ident.version.is_none() {
                 pkg_ident.version = Some(String::from("1.0.0"));
             }
-            if let None = pkg_ident.release {
+            if pkg_ident.release.is_none() {
                 pkg_ident.release = Some(
                     time::now_utc()
                         .strftime("%Y%m%d%H%M%S")

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -83,6 +83,6 @@ pub mod test_support {
         );
 
         PackageInstall::load(&pkg_ident, Some(fs_root))
-            .expect(&format!("PackageInstall should load for {}", &pkg_ident))
+            .unwrap_or_else(|_| panic!("PackageInstall should load for {}", &pkg_ident))
     }
 }

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -39,11 +39,10 @@ pub mod test_support {
     use time;
 
     pub fn fixture_path(name: &str) -> PathBuf {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests")
             .join("fixtures")
-            .join(name);
-        path
+            .join(name)
     }
 
     /// Creates a minimal installed package under an fs_root and return a corresponding loaded

--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -38,7 +38,7 @@ impl Plan {
                 // or a plan file syntax that's in a different language that we do
                 // have a parser for (LUA!), but both of those things are beyond the
                 // scope of this task.
-                let parts: Vec<&str> = line.splitn(2, "=").map(|x| x.trim()).collect();
+                let parts: Vec<&str> = line.splitn(2, '=').map(|x| x.trim()).collect();
 
                 if parts.len() != 2 {
                     continue;

--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -18,63 +18,63 @@ use crate::error::{Error, Result};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Plan {
-  pub name: String,
-  pub origin: String,
-  pub version: Option<String>,
+    pub name: String,
+    pub origin: String,
+    pub version: Option<String>,
 }
 
 impl Plan {
-  pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-    let mut name: Option<String> = None;
-    let mut origin: Option<String> = None;
-    let mut version: Option<String> = None;
-    for line in bytes.lines() {
-      if let Ok(line) = line {
-        // Rather than just blindly accepting values, let's trim all the
-        // whitespace first, verify that we actually have 2 things separated
-        // by an equal sign, and strip out quotes of any kind.
-        //
-        // To do this properly, we probably need some kind of bash parser,
-        // or a plan file syntax that's in a different language that we do
-        // have a parser for (LUA!), but both of those things are beyond the
-        // scope of this task.
-        let parts: Vec<&str> = line.splitn(2, "=").map(|x| x.trim()).collect();
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let mut name: Option<String> = None;
+        let mut origin: Option<String> = None;
+        let mut version: Option<String> = None;
+        for line in bytes.lines() {
+            if let Ok(line) = line {
+                // Rather than just blindly accepting values, let's trim all the
+                // whitespace first, verify that we actually have 2 things separated
+                // by an equal sign, and strip out quotes of any kind.
+                //
+                // To do this properly, we probably need some kind of bash parser,
+                // or a plan file syntax that's in a different language that we do
+                // have a parser for (LUA!), but both of those things are beyond the
+                // scope of this task.
+                let parts: Vec<&str> = line.splitn(2, "=").map(|x| x.trim()).collect();
 
-        if parts.len() != 2 {
-          continue;
+                if parts.len() != 2 {
+                    continue;
+                }
+
+                let mut val = parts[1].replace("\"", "");
+                val = val.replace("'", "");
+
+                match parts[0] {
+                    "pkg_name" | "$pkg_name" => name = Some(val),
+                    "pkg_origin" | "$pkg_origin" => origin = Some(val),
+                    "pkg_version" | "$pkg_version" => version = Some(val),
+                    _ => (),
+                }
+            }
         }
 
-        let mut val = parts[1].replace("\"", "");
-        val = val.replace("'", "");
-
-        match parts[0] {
-          "pkg_name" | "$pkg_name" => name = Some(val),
-          "pkg_origin" | "$pkg_origin" => origin = Some(val),
-          "pkg_version" | "$pkg_version" => version = Some(val),
-          _ => (),
+        if name.is_none() || origin.is_none() {
+            return Err(Error::PlanMalformed);
         }
-      }
-    }
 
-    if name.is_none() || origin.is_none() {
-      return Err(Error::PlanMalformed);
+        Ok(Plan {
+            name: name.unwrap(),
+            origin: origin.unwrap(),
+            version: version,
+        })
     }
-
-    Ok(Plan {
-      name: name.unwrap(),
-      origin: origin.unwrap(),
-      version: version,
-    })
-  }
 }
 
 #[cfg(test)]
 mod test {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn parsing_plan_with_no_quotes_works() {
-    let content = r#"
+    #[test]
+    fn parsing_plan_with_no_quotes_works() {
+        let content = r#"
         pkg_origin=neurosis
         pkg_name=testapp
         pkg_version=0.1.3
@@ -105,15 +105,15 @@ mod test {
           return 0
         }
         "#;
-    let plan = Plan::from_bytes(content.as_bytes()).unwrap();
-    assert_eq!(plan.origin, "neurosis".to_string());
-    assert_eq!(plan.name, "testapp".to_string());
-    assert_eq!(plan.version, Some("0.1.3".to_string()));
-  }
+        let plan = Plan::from_bytes(content.as_bytes()).unwrap();
+        assert_eq!(plan.origin, "neurosis".to_string());
+        assert_eq!(plan.name, "testapp".to_string());
+        assert_eq!(plan.version, Some("0.1.3".to_string()));
+    }
 
-  #[test]
-  fn parsing_plan_with_double_quotes_works() {
-    let content = r#"
+    #[test]
+    fn parsing_plan_with_double_quotes_works() {
+        let content = r#"
         pkg_origin="neurosis"
         pkg_name="testapp"
         pkg_version="0.1.3"
@@ -144,15 +144,15 @@ mod test {
           return 0
         }
         "#;
-    let plan = Plan::from_bytes(content.as_bytes()).unwrap();
-    assert_eq!(plan.origin, "neurosis".to_string());
-    assert_eq!(plan.name, "testapp".to_string());
-    assert_eq!(plan.version, Some("0.1.3".to_string()));
-  }
+        let plan = Plan::from_bytes(content.as_bytes()).unwrap();
+        assert_eq!(plan.origin, "neurosis".to_string());
+        assert_eq!(plan.name, "testapp".to_string());
+        assert_eq!(plan.version, Some("0.1.3".to_string()));
+    }
 
-  #[test]
-  fn parsing_plan_with_single_quotes_works() {
-    let content = r#"
+    #[test]
+    fn parsing_plan_with_single_quotes_works() {
+        let content = r#"
         pkg_origin='neurosis'
         pkg_name='testapp'
         pkg_version='0.1.3'
@@ -183,15 +183,15 @@ mod test {
           return 0
         }
         "#;
-    let plan = Plan::from_bytes(content.as_bytes()).unwrap();
-    assert_eq!(plan.origin, "neurosis".to_string());
-    assert_eq!(plan.name, "testapp".to_string());
-    assert_eq!(plan.version, Some("0.1.3".to_string()));
-  }
+        let plan = Plan::from_bytes(content.as_bytes()).unwrap();
+        assert_eq!(plan.origin, "neurosis".to_string());
+        assert_eq!(plan.name, "testapp".to_string());
+        assert_eq!(plan.version, Some("0.1.3".to_string()));
+    }
 
-  #[test]
-  fn parsing_windows_plan_works() {
-    let content = r#"
+    #[test]
+    fn parsing_windows_plan_works() {
+        let content = r#"
         $pkg_name="testapp"
         $pkg_origin="neurosis"
         $pkg_version="1.04"
@@ -203,9 +203,9 @@ mod test {
         function Invoke-Install {
         }
         "#;
-    let plan = Plan::from_bytes(content.as_bytes()).unwrap();
-    assert_eq!(plan.origin, "neurosis".to_string());
-    assert_eq!(plan.name, "testapp".to_string());
-    assert_eq!(plan.version, Some("1.04".to_string()));
-  }
+        let plan = Plan::from_bytes(content.as_bytes()).unwrap();
+        assert_eq!(plan.origin, "neurosis".to_string());
+        assert_eq!(plan.name, "testapp".to_string());
+        assert_eq!(plan.version, Some("1.04".to_string()));
+    }
 }

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -130,7 +130,7 @@ impl ServiceGroup {
     pub fn validate(value: &str) -> Result<()> {
         let caps = SG_FROM_STR_RE
             .captures(value)
-            .ok_or(Error::InvalidServiceGroup(value.to_string()))?;
+            .ok_or_else(|| Error::InvalidServiceGroup(value.to_string()))?;
         if caps.name("service").is_none() {
             return Err(Error::InvalidServiceGroup(value.to_string()));
         }
@@ -276,7 +276,7 @@ impl ApplicationEnvironment {
     pub fn validate(value: &str) -> Result<()> {
         let caps = AE_FROM_STR_RE
             .captures(value)
-            .ok_or(Error::InvalidApplicationEnvironment(value.to_string()))?;
+            .ok_or_else(|| Error::InvalidApplicationEnvironment(value.to_string()))?;
         if caps.name("application").is_none() {
             return Err(Error::InvalidApplicationEnvironment(value.to_string()));
         }

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -379,7 +379,7 @@ impl FromStr for HealthCheckInterval {
     type Err = ParseIntError;
     fn from_str(s: &str) -> result::Result<Self, Self::Err> {
         let raw = s.parse::<u32>()?;
-        Ok(Duration::from_secs(raw as u64).into())
+        Ok(Duration::from_secs(u64::from(raw)).into())
     }
 }
 

--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -15,11 +15,11 @@
 use crate::env;
 
 /// Default Builder URL environment variable
-pub const BLDR_URL_ENVVAR: &'static str = "HAB_BLDR_URL";
+pub const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
 /// Default Builder URL
-pub const DEFAULT_BLDR_URL: &'static str = "https://bldr.habitat.sh";
+pub const DEFAULT_BLDR_URL: &str = "https://bldr.habitat.sh";
 /// Legacy environment variable for defining a default Builder endpoint
-const LEGACY_BLDR_URL_ENVVAR: &'static str = "HAB_DEPOT_URL";
+const LEGACY_BLDR_URL_ENVVAR: &str = "HAB_DEPOT_URL";
 
 // Returns a Builder URL value if set in the environment. Does *not*
 // return any default value if the value was not found in the environment!

--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -30,5 +30,5 @@ pub fn bldr_url_from_env() -> Option<String> {
 }
 
 pub fn default_bldr_url() -> String {
-    bldr_url_from_env().unwrap_or(DEFAULT_BLDR_URL.to_string())
+    bldr_url_from_env().unwrap_or_else(|| DEFAULT_BLDR_URL.to_string())
 }

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -22,7 +22,7 @@ static GOOGLE_DNS: &'static str = "8.8.8.8:53";
 
 pub fn ip() -> Result<IpAddr> {
     let socket = UdpSocket::bind("0.0.0.0:0")?;
-    let _ = socket.connect(GOOGLE_DNS)?;
+    socket.connect(GOOGLE_DNS)?;
     let addr = socket.local_addr()?;
     Ok(addr.ip())
 }

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -49,9 +49,7 @@ mod ssl {
     pub fn set_ca(ctx: &mut SslContextBuilder, fs_root_path: Option<&Path>) -> Result<()> {
         let cacerts_ident = PackageIdent::from_str(CACERTS_PKG_IDENT)?;
 
-        if let Ok(_) = env::var("SSL_CERT_FILE") {
-            ctx.set_default_verify_paths()?;
-        } else if let Ok(_) = env::var("SSL_CERT_DIR") {
+        if env::var("SSL_CERT_FILE").is_ok() || env::var("SSL_CERT_DIR").is_ok() {
             ctx.set_default_verify_paths()?;
         } else if let Ok(pkg_install) = PackageInstall::load(&cacerts_ident, fs_root_path) {
             let pkg_certs = pkg_install.installed_path().join("ssl/cert.pem");

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -43,8 +43,8 @@ mod ssl {
 
     use crate::error::Result;
 
-    const CACERTS_PKG_IDENT: &'static str = "core/cacerts";
-    const CACERT_PEM: &'static str = include_str!(concat!(env!("OUT_DIR"), "/cacert.pem"));
+    const CACERTS_PKG_IDENT: &str = "core/cacerts";
+    const CACERT_PEM: &str = include_str!(concat!(env!("OUT_DIR"), "/cacert.pem"));
 
     pub fn set_ca(ctx: &mut SslContextBuilder, fs_root_path: Option<&Path>) -> Result<()> {
         let cacerts_ident = PackageIdent::from_str(CACERTS_PKG_IDENT)?;


### PR DESCRIPTION
This brings the Clippy lints being used in line with what we're currently using in [habitat-sh/habitat](https://github.com/habitat-sh/habitat).

Keeping them in sync helps when developing features that involve both crates.