### PR TITLE
Derive necessary traits for ChannelIdent: Deserialize, Serialize, Eq, Hash

### DIFF
--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -77,7 +77,7 @@ lazy_static::lazy_static! {
 }
 
 /// A Builder channel
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ChannelIdent(String);
 
 impl ChannelIdent {


### PR DESCRIPTION
Further work on integrating `ChannelIdent` into [habitat](https://github.com/habitat-sh/habitat/pull/6074) and [builder](https://github.com/habitat-sh/builder/pull/881) showed the need for this additional functionality. Those PRs will be blocked until this merges.