### PR TITLE
[core] Remove Linux capabilities code from macOS target.

### DIFF
--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -224,7 +224,7 @@
 //! <symkey_base64>
 //! ```
 
-use crate::rust_crypto;
+use crypto;
 use std::path::{Path, PathBuf};
 
 use crate::env as henv;
@@ -284,7 +284,7 @@ where
     T: AsRef<[u8]>,
     U: AsRef<[u8]>,
 {
-    rust_crypto::util::fixed_time_eq(t.as_ref(), u.as_ref())
+    crypto::util::fixed_time_eq(t.as_ref(), u.as_ref())
 }
 
 #[cfg(test)]

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -12,31 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate ansi_term;
-extern crate base64;
-#[cfg(target_os = "linux")]
-extern crate caps;
-extern crate crypto as rust_crypto;
-#[cfg(windows)]
-extern crate ctrlc;
-
+// Convenience importing of `debug!`/`info!` macros for entire crate.
 #[macro_use]
 extern crate log;
-
-#[macro_use]
-extern crate serde_derive;
-
-#[cfg(not(windows))]
-extern crate users as linux_users;
-
-#[cfg(windows)]
-extern crate habitat_win_users;
-#[cfg(windows)]
-extern crate widestring;
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate windows_acl;
 
 pub use self::error::{Error, Result};
 

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -15,8 +15,8 @@
 use std::path::PathBuf;
 
 use crate::error::{Error, Result};
-use crate::linux_users;
-use crate::linux_users::os::unix::{GroupExt, UserExt};
+use users;
+use users::os::unix::{GroupExt, UserExt};
 
 /// This is currently the "master check" for whether the Supervisor
 /// can behave "as root".
@@ -41,16 +41,16 @@ pub fn can_run_services_as_svc_user() -> bool {
 }
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
-    linux_users::get_user_by_name(owner).map(|u| u.uid())
+    users::get_user_by_name(owner).map(|u| u.uid())
 }
 
 pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    linux_users::get_group_by_name(group).map(|g| g.gid())
+    users::get_group_by_name(group).map(|g| g.gid())
 }
 
 /// Any members that fail conversion from OsString to string will be omitted
 pub fn get_members_by_groupname(group: &str) -> Option<Vec<String>> {
-    linux_users::get_group_by_name(group).map(|g| {
+    users::get_group_by_name(group).map(|g| {
         g.members()
             .to_vec()
             .into_iter()
@@ -60,31 +60,31 @@ pub fn get_members_by_groupname(group: &str) -> Option<Vec<String>> {
 }
 
 pub fn get_current_username() -> Option<String> {
-    linux_users::get_current_username().and_then(|os_string| os_string.into_string().ok())
+    users::get_current_username().and_then(|os_string| os_string.into_string().ok())
 }
 
 pub fn get_current_groupname() -> Option<String> {
-    linux_users::get_current_groupname().and_then(|os_string| os_string.into_string().ok())
+    users::get_current_groupname().and_then(|os_string| os_string.into_string().ok())
 }
 
 pub fn get_effective_username() -> Option<String> {
-    linux_users::get_effective_username().and_then(|os_string| os_string.into_string().ok())
+    users::get_effective_username().and_then(|os_string| os_string.into_string().ok())
 }
 
 pub fn get_effective_uid() -> u32 {
-    linux_users::get_effective_uid()
+    users::get_effective_uid()
 }
 
 pub fn get_effective_gid() -> u32 {
-    linux_users::get_effective_gid()
+    users::get_effective_gid()
 }
 
 pub fn get_effective_groupname() -> Option<String> {
-    linux_users::get_effective_groupname().and_then(|os_string| os_string.into_string().ok())
+    users::get_effective_groupname().and_then(|os_string| os_string.into_string().ok())
 }
 
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
-    linux_users::get_user_by_name(username).map(|u| PathBuf::from(u.home_dir()))
+    users::get_user_by_name(username).map(|u| PathBuf::from(u.home_dir()))
 }
 
 pub fn root_level_account() -> String {

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -19,6 +19,7 @@ use std::result;
 use std::str::FromStr;
 
 use regex::Regex;
+use serde_derive::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 use crate::package::PackageTarget;

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -21,6 +21,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use serde_derive::{Deserialize, Serialize};
 use toml;
 use toml::Value;
 

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -23,6 +23,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::vec::IntoIter;
 
+use serde_derive::Serialize;
+
 use crate::error::{Error, Result};
 use crate::package::PackageIdent;
 

--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -14,6 +14,8 @@
 
 use std::io::BufRead;
 
+use serde_derive::{Deserialize, Serialize};
+
 use crate::error::{Error, Result};
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -538,6 +538,7 @@ impl<'a> Iterator for Iter<'a> {
 mod test {
     use super::*;
 
+    use serde_derive::{Deserialize, Serialize};
     use toml;
 
     // This test explicitly runs the function which returns the active `PackageTarget` for the

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use regex::Regex;
+use serde_derive::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 


### PR DESCRIPTION
This change allows the `core` crate to be compiled on macOS systems and additionally eliminates almost all of the `extern crate` declarations which cuts down on the number platform-dependent attributes.

I have some further refactoring work to try and clarify the differences we have between "unixlike" systems (i.e. Linux and macOS) and Windows systems. I'm hoping that this changeset is small enough to fix the macOS target and reduce short term confusion until we clean up a bit more. :cake: