### PR TITLE
Fix BoxKeyPair::encrypt return type

### DIFF
--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::str;
 
 use base64;
+use serde_derive::{Deserialize, Serialize};
 use sodiumoxide::crypto::box_;
 use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::PublicKey as BoxPublicKey;
 use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::SecretKey as BoxSecretKey;

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -105,18 +105,13 @@ pub enum Event {
 }
 
 impl fmt::Display for Event {
-    // TODO fn: As of rustfmt 0.7.1 the following match block is not well understood. The tool puts
-    // all match arms on the same line which blows over the 100-column max which then fails the
-    // tool with a `"line exceeded maximum length"` error. This ignore should be removed when we
-    // upgrade rustfmt and retry.
-    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
             Event::ProjectCreate { .. } => "project-create",
-            Event::PackageUpload { .. } => { "package-upload" }
+            Event::PackageUpload { .. } => "package-upload",
             Event::OriginKeyUpload { .. } => "origin-key-upload",
-            Event::OriginSigningKeyUpload { .. } => { "origin-secret-key-upload" }
-            Event::OriginInvitationSend { .. } => { "origin-invitation-send" }
+            Event::OriginSigningKeyUpload { .. } => "origin-secret-key-upload",
+            Event::OriginInvitationSend { .. } => "origin-invitation-send",
             Event::OriginInvitationAccept { .. } => "origin-invitation-accept",
             Event::OriginInvitationIgnore { .. } => "origin-invitation-ignore",
             Event::JobCreate { .. } => "job-create",


### PR DESCRIPTION
See https://github.com/habitat-sh/core/issues/15 for background.

The three commits represent three different levels of fix to `encrypt`'s return Result:
1. Change  from `Vec<u8>` to `String`
2. Use a new `WrappedSealedBox(String)` to improve safety, but add some copy overhead for some consumers
3. Make WrappedSealedBox a [copy-on-write](http://doc.rust-lang.org/1.32.0/std/borrow/enum.Cow.html) type for optimal type-safety *and* no-copy semantics, at the cost of some additional complexity.

Feedback on which approach is best is welcome.

Proposed changes for [`habitat`](https://github.com/habitat-sh/habitat/pull/6116) and [`builder`](https://github.com/habitat-sh/builder/pull/910) follow the same structure (though 2, and 3 for builder are identical).