### PR TITLE
Add missing use statement for serde_derive macros

### DIFF
--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -38,6 +38,8 @@ use std::ffi::OsStr;
 use std::fmt;
 use std::path::PathBuf;
 
+use serde_derive::{Deserialize, Serialize};
+
 pub use crate::os::filesystem;
 pub use crate::os::users;
 


### PR DESCRIPTION
Not sure how this got missed. Please merge at will.