### PR TITLE
Add EnvConfig from habitat as env::Config and implement it for ChannelIdent

### DIFF
--- a/components/core/src/env.rs
+++ b/components/core/src/env.rs
@@ -15,6 +15,7 @@
 use std;
 use std::env::VarError;
 use std::ffi::{OsStr, OsString};
+use std::str::FromStr;
 
 /// Fetches the environment variable `key` from the current process, but only it is not empty.
 ///
@@ -75,5 +76,67 @@ pub fn var_os<K: AsRef<OsStr>>(key: K) -> std::option::Option<OsString> {
             }
         }
         None => None,
+    }
+}
+
+/// Enable the creation of a value based on an environment variable
+/// that can be supplied at runtime by the user.
+pub trait Config: Default + FromStr {
+    /// The environment variable that will be parsed to create an
+    /// instance of `Self`.
+    const ENVVAR: &'static str;
+
+    /// Generate an instance of `Self` from the value of the
+    /// environment variable `Self::ENVVAR`.
+    ///
+    /// If the environment variable is present and not empty, its
+    /// value will be parsed as `Self`. If it cannot be parsed, or the
+    /// environment variable is not present, the default value of the
+    /// type will be given instead.
+    fn configured_value() -> Self {
+        match var(Self::ENVVAR) {
+            Err(VarError::NotPresent) => Self::default(),
+            Ok(val) => match val.parse() {
+                Ok(parsed) => {
+                    Self::log_parsable(&val);
+                    parsed
+                }
+                Err(_) => {
+                    Self::log_unparsable(&val);
+                    Self::default()
+                }
+            },
+            Err(VarError::NotUnicode(nu)) => {
+                Self::log_unparsable(nu.to_string_lossy());
+                Self::default()
+            }
+        }
+    }
+
+    /// Overridable function for logging when an environment variable
+    /// value was found and was successfully parsed as a `Self`.
+    ///
+    /// By default, we log a message at the `warn` level.
+    fn log_parsable(env_value: &str) {
+        warn!(
+            "Found '{}' in environment; using value '{}'",
+            Self::ENVVAR,
+            env_value
+        );
+    }
+
+    /// Overridable function for logging when an environment variable
+    /// value was found and was _not_ successfully parsed as a `Self`.
+    ///
+    /// By default, we log a message at the `warn` level.
+    fn log_unparsable<S>(env_value: S)
+    where
+        S: AsRef<str>,
+    {
+        warn!(
+            "Found '{}' in environment, but value '{}' was unparsable; using default instead",
+            Self::ENVVAR,
+            env_value.as_ref()
+        );
     }
 }


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/issues/6168

There are some compromises here since it's not possible to directly reproduce the previous behavior within the context of the `env::Config` trait. That is, the `HAB_BLDR_CHANNEL` environment variable was used as the primary override for the ChannelIdent default, but if that was not set, it would fall back to trying the legacy environment variable: `HAB_DEPOT_CHANNEL`.

Since `env::Config` uses just one environment variable to provide a `ChannelIdent::configured_value` instance, we can't have the same behavior without putting environment variable overriding logic into `ChannelIdent::default`, which kind of defeats the purpose of the uniform `env::Config` approach.

As such, we instead make a clean break with the legacy approach:
- `ChannelIdent::default` returns the stable channel
- `ChannelIdent::configured_value` returns a `ChannelIdent` instance for the  value in  `HAB_BLDR_CHANNEL` if set and the default value otherwise
- `HAB_DEPOT_CHANNEL` no longer has any special treatment