### PR TITLE
Adds BUILD_DEPS and BUILD_TDEPS to available metadata types

### DIFF
--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -210,7 +210,6 @@ impl PackageArchive {
     ///
     /// # Failures
     ///
-    /// * If a `DEPS` metafile is not found in the archive
     /// * If the archive cannot be read
     /// * If the archive cannot be verified
     pub fn deps(&mut self) -> Result<Vec<PackageIdent>> {
@@ -222,11 +221,32 @@ impl PackageArchive {
     ///
     /// # Failures
     ///
-    /// * If a `TDEPS` metafile is not found in the archive
     /// * If the archive cannot be read
     /// * If the archive cannot be verified
     pub fn tdeps(&mut self) -> Result<Vec<PackageIdent>> {
         self.read_deps(MetaFile::TDeps)
+    }
+
+    /// Returns a list of package identifiers representing the buildtime package dependencies for
+    /// this archive.
+    ///
+    /// # Failures
+    ///
+    /// * If the archive cannot be read
+    /// * If the archive cannot be verified
+    pub fn build_deps(&mut self) -> Result<Vec<PackageIdent>> {
+        self.read_deps(MetaFile::BuildDeps)
+    }
+
+    /// Returns a list of package identifiers representing the transitive buildtime package
+    /// dependencies for this archive.
+    ///
+    /// # Failures
+    ///
+    /// * If the archive cannot be read
+    /// * If the archive cannot be verified
+    pub fn build_tdeps(&mut self) -> Result<Vec<PackageIdent>> {
+        self.read_deps(MetaFile::BuildTDeps)
     }
 
     pub fn exposes(&mut self) -> Result<Vec<u16>> {

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -173,6 +173,8 @@ pub enum MetaFile {
     BindMap, // Composite-only
     Binds,
     BindsOptional,
+    BuildDeps,
+    BuildTDeps,
     CFlags,
     Config,
     Deps,
@@ -202,6 +204,8 @@ impl fmt::Display for MetaFile {
             MetaFile::BindMap => "BIND_MAP",
             MetaFile::Binds => "BINDS",
             MetaFile::BindsOptional => "BINDS_OPTIONAL",
+            MetaFile::BuildDeps => "BUILD_DEPS",
+            MetaFile::BuildTDeps => "BUILD_TDEPS",
             MetaFile::CFlags => "CFLAGS",
             MetaFile::Config => "default.toml",
             MetaFile::Deps => "DEPS",


### PR DESCRIPTION
Some necessary additions for making build deps integration to the build graph.

Signed-off-by: Ian Henry <ihenry@chef.io>