### PR TITLE
Raise client connection timeout

### DIFF
--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -45,7 +45,7 @@ use crate::{error::{Error,
             ssl};
 
 // Read and write TCP socket timeout for Hyper/HTTP client calls.
-const CLIENT_SOCKET_RW_TIMEOUT_SEC: u64 = 120;
+const CLIENT_SOCKET_RW_TIMEOUT_SEC: u64 = 300;
 
 header! { (ProxyAuthorization, "Proxy-Authorization") => [String] }
 


### PR DESCRIPTION
We need to raise the default timeout for the API client in order to accommodate large file uploads to Builder.  This (along with adjustment to the ELB idle timeout) resolves https://github.com/habitat-sh/builder/issues/961
 
Signed-off-by: Salim Alam <salam@chef.io>

![tenor-76384458](https://user-images.githubusercontent.com/13542112/54637570-29257e80-4a46-11e9-9dfe-2d3e04a96d12.gif)
