### PR TITLE
Correctly run clippy in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ matrix:
         - ./support/ci/compile_zmq.sh
         - source ./support/ci/rust_env.sh
       script:
+        - make lint
         - ./support/ci/rust_tests.sh
         - ./support/ci/rustfmt.sh
-        - make lint
 
 notifications:
   webhooks:


### PR DESCRIPTION
Clippy leverages `cargo check`, so running it after other tests may cause some lints to not be triggered. To increase effectiveness (and move fatal errors toward the bottom of the CI output), run clippy first.
