### PR TITLE
Adds more build_dep and build_tdep functionality

### DIFF
--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -76,6 +76,22 @@ lazy_static::lazy_static! {
             .unwrap(),
         );
         map.insert(
+            MetaFile::BuildDeps,
+            Regex::new(&format!(
+                r"^/?hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$",
+                MetaFile::BuildDeps,
+            ))
+            .unwrap(),
+        );
+        map.insert(
+            MetaFile::BuildTDeps,
+            Regex::new(&format!(
+                r"^/?hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$",
+                MetaFile::BuildTDeps,
+            ))
+            .unwrap(),
+        );
+        map.insert(
             MetaFile::Exposes,
             Regex::new(&format!(
                 r"^/?hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$",

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -352,6 +352,12 @@ impl PackageInstall {
     /// Return all transitive dependencies of the package
     pub fn tdeps(&self) -> Result<Vec<PackageIdent>> { self.read_deps(MetaFile::TDeps) }
 
+    /// Return all build dependencies of the package
+    pub fn build_deps(&self) -> Result<Vec<PackageIdent>> { self.read_deps(MetaFile::BuildDeps) }
+
+    /// Return all transitive build dependencies of the package
+    pub fn build_tdeps(&self) -> Result<Vec<PackageIdent>> { self.read_deps(MetaFile::BuildTDeps) }
+
     /// Returns a Rust representation of the mappings defined by the `pkg_exports` plan variable.
     ///
     /// These mappings are used as a filter-map to generate a public configuration when the package


### PR DESCRIPTION
Not extracting the build_dep and build_tdep data into the hashmap meant not being able to actually utilize this information in any meaningful way.

Signed-off-by: Ian Henry <ihenry@chef.io>