### PR TITLE
rustfmt update post 0.79.0 release

### DIFF
--- a/support/ci/shared.sh
+++ b/support/ci/shared.sh
@@ -13,7 +13,7 @@ get_current_toolchain() {
   # break the way rustfmt uses rustc. Therefore, before updating the pin below, double check
   # that the nightly version you're going to update it to includes rustfmt. You can do that
   # using https://mexus.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  echo "nightly-2019-03-18"
+  echo "nightly-2019-04-09"
 }
 
 install_rust_toolchain() {


### PR DESCRIPTION
Update toolchain to nightly-2019-04-09

There were no changes when running `cargo +nightly-2019-04-09 fmt`
